### PR TITLE
Dockerfile: fetch build dependencies in a separate layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 # Build the operator
 FROM registry.access.redhat.com/ubi8/go-toolset AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/node-feature-discovery-operator
-COPY . .
+
+# Fetch/cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
 
 # do the actual build
+COPY . .
 RUN make build
 
 # Create production image for running the operator


### PR DESCRIPTION
Effectively caches them, making subsequent builds much faster (assuming
go.mod and go.sum) are not changed).