### PR TITLE
Use official golang image as BUILDER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+FROM golang:1.13 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/node-feature-discovery-operator
 
 # Fetch/cache dependencies


### PR DESCRIPTION
prow job
testgrid.k8s.io/sig-node-node-feature-discovery#operator-push-image is
failing, this might be because we are using golang from UBI which comes
with a default user that sometimes depending on the build environment
doesn't have write persmisions.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>
