### PR TITLE
Bumb golang version to 1.14.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator
-FROM golang:1.13 AS builder
+FROM golang:1.14.7 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/node-feature-discovery-operator
 
 # Fetch/cache dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/node-feature-discovery-operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/go-openapi/spec v0.19.3


### PR DESCRIPTION
NFD operand is using 1.14.7 already, the operator should be kept in sync

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>