### PR TITLE
Makefile: disable golangci-lint in verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ undeploy:
 		$(TEMPLATE_CMD) $$obj | kubectl delete -f - ;\
 	done	
 
-verify:	verify-gofmt ci-lint
+verify:	verify-gofmt # ci-lint
 
 verify-gofmt:
 	@./scripts/verify-gofmt.sh	


### PR DESCRIPTION
Disable linting until master passes muster so that PRs are not blocked
because of linting failures.