### PR TITLE
Update default operand image

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	nodeFeautreDiscoveryImageDefault string = "quay.io/kubernetes_incubator/node-feature-discovery:latest"
+	nodeFeautreDiscoveryImageDefault string = "k8s.gcr.io/nfd/node-feature-discovery:v0.6.0"
 )
 
 var log = logf.Log.WithName("config")


### PR DESCRIPTION
Walking towards a first release of the Operator, we should sync Operand latest release with the latest (not yet released) version of the operator 
moving from temporal registry quay.io/kubernetes_incubator/node-feature-discovery:latest -> k8s.gcr.io/nfd/node-feature-discovery:v0.6.0
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>