### PR TITLE
Enable issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug encountered while operating the Node-Feature-Discovery-Operator
+about: Report a bug encountered while using Node Feature Discovery Operator
 labels: kind/bug
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug encountered while operating the Node-Feature-Discovery-Operator
+labels: kind/bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/
+-->
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- Cloud provider or hardware configuration:
+- OS (e.g: `cat /etc/os-release`):
+- Kernel (e.g. `uname -a`):
+- Install tools:
+- Network plugin and version (if this is a network-related bug):
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,6 @@
 ---
 name: Enhancement Request
-about: Suggest an enhancement to the Node-Feature-Discovery-Operator project
+about: Suggest an enhancement to the Node Feature Discovery Operator project
 labels: kind/feature
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the Node-Feature-Discovery-Operator project
+labels: kind/feature
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,6 +1,6 @@
 ---
 name: Support Request
-about: Support request or question relating to Node-Feature-Discovery-Operator
+about: Support request or question relating to Node Feature Discovery Operator
 labels: triage/support
 
 ---

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,19 @@
+---
+name: Support Request
+about: Support request or question relating to Node-Feature-Discovery-Operator
+labels: triage/support
+
+---
+
+<!--
+STOP -- PLEASE READ!
+
+GitHub is not the right place for support requests.
+
+If you're looking for help, check the [troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/)
+or our [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
+
+You can also post your question on the [Slack channel](https://kubernetes.slack.com/messages/node-feature-discovery)
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/.
+-->


### PR DESCRIPTION
Thinking on #11 is a good idea to do some GitHub maintenance on the repo
to enable a better communication.

This commit adds templates for bug report, feature request and support
related issues.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>