### PR TITLE
Enhance nfd-worker placement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean:
 	rm -f $(BIN)
 
 clean-labels:
-	@$(shell kubectl get no -o yaml | sed -e '/^\s*nfd.node.kubernetes.io/d' -e '/^\s*feature.node.kubernetes.io/d' | kubectl replace -f -)
+	kubectl get no -o yaml | sed -e '/^\s*nfd.node.kubernetes.io/d' -e '/^\s*feature.node.kubernetes.io/d' | kubectl replace -f -
 
 image:
 	$(IMAGE_BUILD_CMD) -t $(IMAGE_TAG) \

--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: nfd-worker
     spec:
+      tolerations:
+      - operator: "Exists"
+        effect: "NoSchedule"
+
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -16,7 +16,6 @@ spec:
       tolerations:
       - operator: "Exists"
         effect: "NoSchedule"
-
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -13,8 +13,13 @@ spec:
       labels:
         app: nfd-worker
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key:  node-role.kubernetes.io/master
+                operator: DoesNotExist
       hostNetwork: true
       serviceAccount: nfd-worker
       readOnlyRootFilesystem: true


### PR DESCRIPTION
Enable NFD operator to deploy nfd-worker pods on nodes labeled other
than "node-role.kubernetes.io/worker"

Also:  Fix clean-labels make target

Closes: #29
Closes: #30