### PR TITLE
Fix golangci-lint verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ undeploy:
 		$(TEMPLATE_CMD) $$obj | kubectl delete -f - ;\
 	done
 
-verify:	verify-gofmt # ci-lint
+verify:	verify-gofmt ci-lint
 
 verify-gofmt:
 	@./scripts/verify-gofmt.sh

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,9 +31,10 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	zap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 var log = logf.Log.WithName("cmd")
@@ -51,7 +52,7 @@ func main() {
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(zap.Logger(false))
 
 	printVersion()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,15 +18,11 @@ package config
 
 import (
 	"os"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 const (
 	nodeFeautreDiscoveryImageDefault string = "quay.io/kubernetes_incubator/node-feature-discovery:latest"
 )
-
-var log = logf.Log.WithName("config")
 
 // NodeFeatureDiscoveryImage returns the operator's operand/nfd image path.
 func NodeFeatureDiscoveryImage() string {

--- a/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
+++ b/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
@@ -35,8 +35,8 @@ type controlFunc []func(n NFD) (ResourceStatus, error)
 type ResourceStatus int
 
 const (
-	Ready    ResourceStatus = 0
-	NotReady ResourceStatus = 1
+	Ready ResourceStatus = iota
+	NotReady
 )
 
 func (s ResourceStatus) String() string {

--- a/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_resources.go
+++ b/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_resources.go
@@ -35,8 +35,6 @@ import (
 
 type assetsFromFile []byte
 
-var manifests []assetsFromFile
-
 type Resources struct {
 	Namespace                  corev1.Namespace
 	ServiceAccount             corev1.ServiceAccount

--- a/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_state.go
+++ b/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_state.go
@@ -30,32 +30,25 @@ type NFD struct {
 	idx       int
 }
 
-func addState(n *NFD, path string) error {
-
+func (n *NFD) addState(path string) {
 	res, ctrl := addResourcesControls(path)
-
 	n.controls = append(n.controls, ctrl)
 	n.resources = append(n.resources, res)
-
-	return nil
 }
 
-func (n *NFD) init(r *ReconcileNodeFeatureDiscovery,
-	i *nfdv1alpha1.NodeFeatureDiscovery) error {
+func (n *NFD) init(
+	r *ReconcileNodeFeatureDiscovery,
+	i *nfdv1alpha1.NodeFeatureDiscovery,
+) {
 	n.rec = r
 	n.ins = i
 	n.idx = 0
-
-	addState(n, "/opt/nfd/master")
-	addState(n, "/opt/nfd/worker")
-
-	return nil
+	n.addState("/opt/nfd/master")
+	n.addState("/opt/nfd/worker")
 }
 
 func (n *NFD) step() error {
-
 	for _, fs := range n.controls[n.idx] {
-
 		stat, err := fs(*n)
 		if err != nil {
 			return err
@@ -64,19 +57,10 @@ func (n *NFD) step() error {
 			return errors.New("ResourceNotReady")
 		}
 	}
-
 	n.idx = n.idx + 1
-
 	return nil
 }
 
-func (n NFD) validate() {
-	// TODO add custom validation functions
-}
-
-func (n NFD) last() bool {
-	if n.idx == len(n.controls) {
-		return true
-	}
-	return false
+func (n *NFD) last() bool {
+	return n.idx == len(n.controls)
 }


### PR DESCRIPTION
Fixes #23 

FIx golangci-lint verify
- Fix zap logger creation
- Light to changes to `nodefeaturediscovery.NFD` struct
- Remove unused variables/methods

```bash
make verify                                                                      
gofmt OK
golangci-lint run --timeout 5m0s
```