### PR TITLE
master:worker nodes enablement for nfd-worker

### DIFF
--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -14,15 +14,18 @@ spec:
         app: nfd-worker
     spec:
       tolerations:
-      - operator: "Exists"
-        effect: "NoSchedule"
+        - operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key:  node-role.kubernetes.io/master
-                operator: DoesNotExist
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/node
+                    operator: Exists
       hostNetwork: true
       serviceAccount: nfd-worker
       readOnlyRootFilesystem: true


### PR DESCRIPTION
After https://github.com/kubernetes-sigs/node-feature-discovery-operator/pull/31 three node cluster, where all nodes will have the master and worker(or node for vanilla clusters) labels are just getting the nfd-master daemonset deployed. Since they have the master label, the NFD workers will not be scheduled.

This Patch fix that adding support for master:worker type of nodes, being used in edge deployments 

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>