### PR TITLE
remove duplicated version on CRD

### DIFF
--- a/manifests/0500_crd.yaml
+++ b/manifests/0500_crd.yaml
@@ -10,7 +10,6 @@ spec:
     plural: nodefeaturediscoveries
     singular: nodefeaturediscovery
   scope: Namespaced
-  version: v1alpha1
   subresources:
     status: {}
   preserveUnknownFields: false
@@ -40,4 +39,3 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-


### PR DESCRIPTION
remove duplicated `version` entry in the CRD object , can lead to confusion 
Also rm extra white lines

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>