### PR TITLE
fix wrong variable naming leading to failing deployment

### DIFF
--- a/manifests/0500_crd.yaml
+++ b/manifests/0500_crd.yaml
@@ -55,13 +55,13 @@ spec:
                   namespace:
                     pattern: '[a-zA-Z0-9\.\-\/]+'
                     type: string
-              nfd-worker:
+              workerConfig:
                 description: NFD configuration files
                 type: object
                 required:
-                  - config
+                  - configData
                 properties:
-                  config:
+                  configData:
                     description: NFD Worker configuration file
                     type: string
           status:

--- a/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
+++ b/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
@@ -258,8 +258,8 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 	obj.SetNamespace(n.ins.GetNamespace())
 
 	// Update ConfigMap
-	obj.ObjectMeta.Name = "nfd-worker-conf"
-	obj.Data["nfd-worker-conf"] = n.ins.Spec.WorkerConfig.Data()
+	obj.ObjectMeta.Name = "nfd-worker"
+	obj.Data["nfd-worker-conf"] = n.ins.Spec.WorkerConfig.ConfigData
 
 	found := &corev1.ConfigMap{}
 	logger := log.WithValues("ConfigMap", obj.Name, "Namespace", obj.Namespace)


### PR DESCRIPTION
Fix wrong naming schemas that prevent the operator to deploy 

CRD and  CR were using different name schemas
same for the operator  controller 

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>