### PR TITLE
Enable service DNS for nfd-master

### DIFF
--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -27,6 +27,7 @@ spec:
                   - key: node-role.kubernetes.io/node
                     operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccount: nfd-worker
       readOnlyRootFilesystem: true
       containers:
@@ -41,7 +42,7 @@ spec:
             - "nfd-worker"
           args:
             - "--sleep-interval=60s"
-            - "--server=$(NFD_MASTER_SERVICE_HOST):$(NFD_MASTER_SERVICE_PORT)"
+            - "--server=nfd-master:$(NFD_MASTER_SERVICE_PORT)"
           volumeMounts:
             - name: host-boot
               mountPath: "/host-boot"


### PR DESCRIPTION
This Patch enables service DNS for the nfd-master allowing nfd-workers
to discover the NFD server without passing an IP but the service name

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>