### PR TITLE
assets/worker: do not user host network

### DIFF
--- a/build/assets/worker/05_worker_ds.yaml
+++ b/build/assets/worker/05_worker_ds.yaml
@@ -26,7 +26,6 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/node
                     operator: Exists
-      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccount: nfd-worker
       readOnlyRootFilesystem: true


### PR DESCRIPTION
No need for nfd-worker to use hostNetwork, anymore.