### PR TITLE
add support for NFD-Master instance flag

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -26,6 +26,7 @@ import (
 // +k8s:openapi-gen=true
 type NodeFeatureDiscoverySpec struct {
 	Operand      OperandSpec `json:"operand"`
+	Instance     string      `json:"instance"`
 	WorkerConfig ConfigMap   `json:"workerConfig"`
 }
 

--- a/build/assets/master/0400_master_daemonset.yaml
+++ b/build/assets/master/0400_master_daemonset.yaml
@@ -35,4 +35,3 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-

--- a/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -37,6 +37,9 @@ spec:
           spec:
             description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
+              instance:
+                description: Instance name. Used to separate annotation namespaces for multiple parallel deployments.
+                type: string
               operand:
                 description: OperandSpec describes configuration options for the operand
                 properties:
@@ -60,8 +63,7 @@ spec:
                     type: integer
                 type: object
               workerConfig:
-                description: ConfigMap describes configuration options for the NFD
-                  worker
+                description: WorkerConfig describes configuration options for the NFD worker
                 properties:
                   configData:
                     description: BinaryData holds the NFD configuration file

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -311,12 +311,20 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 
 	// update nfd-master service port
 	if obj.ObjectMeta.Name == "nfd-master" {
+		var args []string
 		port := defaultServicePort
 		if n.ins.Spec.Operand.ServicePort != 0 {
 			port = n.ins.Spec.Operand.ServicePort
 		}
-		portFlag := fmt.Sprintf("--port=%d", port)
-		obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
+		args = append(args, fmt.Sprintf("--port=%d", port))
+
+		// check if running as instance
+		// https://kubernetes-sigs.github.io/node-feature-discovery/v0.8/advanced/master-commandline-reference.html#-instance
+		if n.ins.Spec.Instance != "" {
+			args = append(args, fmt.Sprintf("--instance=%s", n.ins.Spec.Instance))
+		}
+
+		obj.Spec.Template.Spec.Containers[0].Args = args
 	}
 
 	obj.SetNamespace(n.ins.GetNamespace())


### PR DESCRIPTION
Issue https://github.com/kubernetes-sigs/node-feature-discovery/issues/427 proposed a way to handle multiple NFD instances on a same cluster , this was addressed with https://github.com/kubernetes-sigs/node-feature-discovery/pull/431 patch 

this patch updated the operator to support multiple instances of NFD on the same cluster

THIS PATCH MUST BE REVIEWED AND MERGED AFTER #53 