### PR TITLE
Minor fixes after upgrading operator sdk

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           command:
-            - /manager
+            - /node-feature-discovery-operator
           args:
             - --leader-elect
             - "--zap-encoder=console"

--- a/controllers/nodefeaturediscovery_state.go
+++ b/controllers/nodefeaturediscovery_state.go
@@ -44,8 +44,10 @@ func (n *NFD) init(
 	n.rec = r
 	n.ins = i
 	n.idx = 0
-	n.addState("/opt/nfd/master")
-	n.addState("/opt/nfd/worker")
+	if len(n.controls) == 0 {
+		n.addState("/opt/nfd/master")
+		n.addState("/opt/nfd/worker")
+	}
 }
 
 func (n *NFD) step() error {


### PR DESCRIPTION
2 minor fixes in an unrelated patch
- https://github.com/kubernetes-sigs/node-feature-discovery-operator/commit/53e6fe7384a82b4b0179ffd36bff62eb9fdc65ee fix wrong command on operator deployment
- https://github.com/kubernetes-sigs/node-feature-discovery-operator/commit/06266fa25437aa4cc653ad2c2e950f9cbd53d955 fix to prevent the operator on accumulating states leading to logs overload