### PR TITLE
Use upstream image

### DIFF
--- a/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   operand:
     namespace: node-feature-discovery-operator
-    image: quay.io/openshift/origin-node-feature-discovery:4.7
+    image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
     imagePullPolicy: Always
   workerConfig:
     configData: |


### PR DESCRIPTION
Use proper upstream image
gcr.io/k8s-staging-nfd/node-feature-discovery:master for the operand
sample CR

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>