### PR TITLE
Add kustomize patch for ClusterRole

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - role.yaml
 - role_binding.yaml
@@ -11,3 +14,22 @@ resources:
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
 
+# needed for nfd-worker
+# this patch is needed given that
+# +kubebuilder does not allow resourceNames
+patchesJSON6902:
+- target:
+    kind: ClusterRole
+    name: manager-role
+  patch: |-
+    - op: add
+      path: /rules/0
+      value:
+        apiGroups:
+        - policy
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - use
+        resourceNames:
+        - nfd-worker


### PR DESCRIPTION
For the proper deployment of nfd-worker we need it to be provided with
specific permisions that can not be set via +kubebuilder

this patch adds a kustomize patch so we can hard code the needed rbac
rules for the porper deployment of the nfd-worker

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>