### PR TITLE
Add kustomize rule for commonAnnotations on CRD

### DIFF
--- a/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -5,7 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-    api-approved.kubernetes.io: "unapproved, experimental-only"
   creationTimestamp: null
   name: nodefeaturediscoveries.nfd.kubernetes.io
 spec:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
 - bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
+commonAnnotations:
+  api-approved.kubernetes.io: "unapproved, experimental-only"
+
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD


### PR DESCRIPTION
Currently `make manifests` resets the CRD file removing a needed
annotation
- api-approved.kubernetes.io: "unapproved, experimental-only"

this patch overrides this autogeneration by adding a kustomize rule commonAnnotations into
config/crd/kustomization.yaml file, allowing kustomize to patch the crd
when `kustomize build config/default` is called, injecting the
annotation.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>