### PR TITLE
Add serviceport var to CRD

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -31,15 +31,26 @@ type NodeFeatureDiscoverySpec struct {
 
 // OperandSpec describes configuration options for the operand
 type OperandSpec struct {
+	// Namespace defines the namespace to deploy nfd-master
+	// and nfd-worker pods
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9\.\-\/]+
 	Namespace string `json:"namespace,omitempty"`
 
+	// Image defines the image to pull for the
+	// NFD operand
+	// [defaults to k8s.gcr.io/nfd/node-feature-discovery]
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9\-]+
 	Image string `json:"image,omitempty"`
 
-	// Image pull policy
+	// ImagePullPolicy defines Image pull policy for the
+	// NFD operand image [defaults to Always]
 	// +kubebuilder:validation:Optional
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+
+	// ServicePort specifies the TCP port that nfd-master
+	// listens for incoming requests.
+	// +kubebuilder:validation:Optional
+	ServicePort int `json:"servicePort"`
 }
 
 // ConfigMap describes configuration options for the NFD worker

--- a/build/assets/master/0400_master_daemonset.yaml
+++ b/build/assets/master/0400_master_daemonset.yaml
@@ -29,7 +29,7 @@ spec:
                 fieldPath: spec.nodeName
           image: $(NODE_FEATURE_DISCOVERY_IMAGE)
           name: nfd-master
-          command: ["nfd-master", "--port=12000"]
+          command: ["nfd-master"]
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -41,14 +41,23 @@ spec:
                 description: OperandSpec describes configuration options for the operand
                 properties:
                   image:
+                    description: Image defines the image to pull for the NFD operand
+                      [defaults to k8s.gcr.io/nfd/node-feature-discovery]
                     pattern: '[a-zA-Z0-9\-]+'
                     type: string
                   imagePullPolicy:
-                    description: Image pull policy
+                    description: ImagePullPolicy defines Image pull policy for the
+                      NFD operand image [defaults to Always]
                     type: string
                   namespace:
+                    description: Namespace defines the namespace to deploy nfd-master
+                      and nfd-worker pods
                     pattern: '[a-zA-Z0-9\.\-\/]+'
                     type: string
+                  servicePort:
+                    description: ServicePort specifies the TCP port that nfd-master
+                      listens for incoming requests.
+                    type: integer
                 type: object
               workerConfig:
                 description: ConfigMap describes configuration options for the NFD

--- a/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
@@ -8,6 +8,7 @@ spec:
     namespace: node-feature-discovery-operator
     image: gcr.io/k8s-staging-nfd/node-feature-discovery:master
     imagePullPolicy: Always
+    servicePort: 12000
   workerConfig:
     configData: |
       #core:

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -310,13 +310,15 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 	}
 
 	// update nfd-master service port
-	if n.ins.Spec.Operand.ServicePort != 0 && obj.ObjectMeta.Name == "nfd-master" {
-		portFlag := fmt.Sprintf("--port=%d", n.ins.Spec.Operand.ServicePort)
-		obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
-	} else if obj.ObjectMeta.Name == "nfd-master" {
-		portFlag := fmt.Sprintf("--port=%d", defaultServicePort)
-		obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
-	}
+        if obj.ObjectMeta.Name == "nfd-master" {
+                port := defaultServicePort
+                if n.ins.Spec.Operand.ServicePort != 0 {
+                        port = n.ins.Spec.Operand.ServicePort
+                }
+                portFlag := fmt.Sprintf("--port=%d", port)
+                obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
+        }
+
 
 	obj.SetNamespace(n.ins.GetNamespace())
 

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -310,15 +310,14 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 	}
 
 	// update nfd-master service port
-        if obj.ObjectMeta.Name == "nfd-master" {
-                port := defaultServicePort
-                if n.ins.Spec.Operand.ServicePort != 0 {
-                        port = n.ins.Spec.Operand.ServicePort
-                }
-                portFlag := fmt.Sprintf("--port=%d", port)
-                obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
-        }
-
+	if obj.ObjectMeta.Name == "nfd-master" {
+		port := defaultServicePort
+		if n.ins.Spec.Operand.ServicePort != 0 {
+			port = n.ins.Spec.Operand.ServicePort
+		}
+		portFlag := fmt.Sprintf("--port=%d", port)
+		obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
+	}
 
 	obj.SetNamespace(n.ins.GetNamespace())
 

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	secv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,6 +26,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -35,6 +37,8 @@ type ResourceStatus int
 const (
 	Ready ResourceStatus = iota
 	NotReady
+
+	defaultServicePort int = 12000
 )
 
 func (s ResourceStatus) String() string {
@@ -305,6 +309,15 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 		obj.Spec.Template.Spec.Containers[0].ImagePullPolicy = n.ins.Spec.Operand.ImagePolicy(n.ins.Spec.Operand.ImagePullPolicy)
 	}
 
+	// update nfd-master service port
+	if n.ins.Spec.Operand.ServicePort != 0 && obj.ObjectMeta.Name == "nfd-master" {
+		portFlag := fmt.Sprintf("--port=%d", n.ins.Spec.Operand.ServicePort)
+		obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
+	} else if obj.ObjectMeta.Name == "nfd-master" {
+		portFlag := fmt.Sprintf("--port=%d", defaultServicePort)
+		obj.Spec.Template.Spec.Containers[0].Args = []string{portFlag}
+	}
+
 	obj.SetNamespace(n.ins.GetNamespace())
 
 	found := &appsv1.DaemonSet{}
@@ -342,6 +355,15 @@ func Service(n NFD) (ResourceStatus, error) {
 
 	state := n.idx
 	obj := n.resources[state].Service
+
+	// update ports
+	if n.ins.Spec.Operand.ServicePort != 0 {
+		obj.Spec.Ports[0].Port = int32(n.ins.Spec.Operand.ServicePort)
+		obj.Spec.Ports[0].TargetPort = intstr.FromInt(n.ins.Spec.Operand.ServicePort)
+	} else {
+		obj.Spec.Ports[0].Port = int32(defaultServicePort)
+		obj.Spec.Ports[0].TargetPort = intstr.FromInt(defaultServicePort)
+	}
 
 	obj.SetNamespace(n.ins.GetNamespace())
 


### PR DESCRIPTION
This patch allows users to modify the nfd-master Service port via CRD
with the variable Operand.ServicePort , will deafult to 12000 when not
defined

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>