### PR TITLE
Provide a way to push the operator bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,3 +208,8 @@ bundle: manifests kustomize
 .PHONY: bundle-build
 bundle-build:
 	$(IMAGE_BUILD_CMD)  -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+# push the bundle image.
+.PHONY: bundle-push
+bundle-push:
+	$(IMAGE_PUSH_CMD) $(BUNDLE_IMG)


### PR DESCRIPTION
this extra helper in the makefile will be needed for those trying to run the operator as a bundle 

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>