### PR TITLE
Make Instance and WorkerConfig optional by default

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -25,9 +25,17 @@ import (
 // NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
 // +k8s:openapi-gen=true
 type NodeFeatureDiscoverySpec struct {
-	Operand      OperandSpec `json:"operand"`
-	Instance     string      `json:"instance"`
-	WorkerConfig ConfigMap   `json:"workerConfig"`
+	Operand OperandSpec `json:"operand"`
+
+	// Instance name. Used to separate annotation namespaces for
+	// multiple parallel deployments.
+	// +optional
+	Instance string `json:"instance"`
+
+	// WorkerConfig describes configuration options for the NFD
+	// worker.
+	// +optional
+	WorkerConfig ConfigMap `json:"workerConfig"`
 }
 
 // OperandSpec describes configuration options for the operand

--- a/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -38,7 +38,8 @@ spec:
             description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
               instance:
-                description: Instance name. Used to separate annotation namespaces for multiple parallel deployments.
+                description: Instance name. Used to separate annotation namespaces
+                  for multiple parallel deployments.
                 type: string
               operand:
                 description: OperandSpec describes configuration options for the operand
@@ -63,7 +64,8 @@ spec:
                     type: integer
                 type: object
               workerConfig:
-                description: WorkerConfig describes configuration options for the NFD worker
+                description: WorkerConfig describes configuration options for the
+                  NFD worker.
                 properties:
                   configData:
                     description: BinaryData holds the NFD configuration file
@@ -73,7 +75,6 @@ spec:
                 type: object
             required:
             - operand
-            - workerConfig
             type: object
           status:
             description: NodeFeatureDiscoveryStatus defines the observed state of

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -316,4 +316,3 @@ rules:
   - update
   - use
   - watch
-

--- a/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nfd-master-server
   namespace: node-feature-discovery-operator
 spec:
+  instance: "" # instance is empty by default
   operand:
     namespace: node-feature-discovery-operator
     image: gcr.io/k8s-staging-nfd/node-feature-discovery:master


### PR DESCRIPTION
This Patchs will prevent the following warning , by making `instance` and `workerconfig` optional on the CRD, and fixing the example to be more explicit to users

```bash
$ kubectl apply -f config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
error: error validating "config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml": error validating data: ValidationError(NodeFeatureDiscovery.spec): missing required field "instance" in io.kubernetes.nfd.v1.NodeFeatureDiscovery.spec; if you choose to ignore these errors, turn validation off with --validate=false
```


Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>