### PR TITLE
docs: show full version number in sidebar

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,8 +45,9 @@ remote_theme: rundocs/jekyll-rtd-theme@v2.0.9
 version: master
 display_version_list: true
 
-# Release is used to make external links to point to the correct blobs in the
-# Github repo
+# Release is the full released version number. Used to make external links to
+# point to the correct blobs in the Github repo. This is also the version shown
+# in the sidebar (top left corner of the page)
 release: master
 
 # Container image which to point to in the documentation

--- a/docs/_includes/class/sidebar-wrap.liquid
+++ b/docs/_includes/class/sidebar-wrap.liquid
@@ -6,7 +6,7 @@
                     <i class="fa fa-home"></i> {{ site.title }}
                 </a>
             </div>
-            <span class="version">{{ site.version }}</span>
+            <span class="version">{{ site.release }}</span>
             <form class="search pt-2" action="{{ site.baseurl }}/search.html" method="get" autocomplete="off">
                 <input class="form-control input-block input-sm" type="text" name="q" placeholder="{{ __.search_docs | default: 'Search docs...' }}">
             </form>


### PR DESCRIPTION
Change the sidebar customization so that the full version (e.g. v0.2.0)
is displayed, instead of the truncated "releae branch version" (e.g.
v0.2) in the top left corner of the page. The items in the version menu
are unchanged and will still show the shorter form.

Cherry picked from node-feature-discovery repo commit
4d19e1ab85b6cf4c6a2f6e556bf04654e4fb238e.