### PR TITLE
fix README to point to master documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ You can reach the maintainers of this project at:
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
 
-[documentation]: https://kubernetes-sigs.github.io/node-feature-discovery-operator
+[documentation]: https://kubernetes-sigs.github.io/node-feature-discovery-operator/master/


### PR DESCRIPTION
As it is currently it takes the user to `stable` , master branch README should point to master on docs 
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>