### PR TITLE
add support for config IMAGE_TAG and rbac proxy image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,11 @@ IMAGE_REGISTRY ?= k8s.gcr.io/nfd
 IMAGE_NAME := node-feature-discovery-operator
 IMAGE_TAG_NAME ?= $(VERSION)
 IMAGE_EXTRA_TAG_NAMES ?=
-IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
-IMAGE_TAG := $(IMAGE_REPO):$(IMAGE_TAG_NAME)
+IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)
+IMAGE_TAG ?= $(IMAGE_REPO):$(IMAGE_TAG_NAME)
 IMAGE_EXTRA_TAGS := $(foreach tag,$(IMAGE_EXTRA_TAG_NAMES),$(IMAGE_REPO):$(tag))
+
+IMAGE_TAG_RBAC_PROXY ?= gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
@@ -110,7 +112,9 @@ uninstall: manifests kustomize
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMAGE_TAG}
+	cd config/manager && \
+		$(KUSTOMIZE) edit set image controller=${IMAGE_TAG} && \
+		$(KUSTOMIZE) edit set image kube-rbac-proxy=${IMAGE_TAG_RBAC_PROXY}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,3 +1,8 @@
+images:
+- name: kube-rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.5.0
+
 # Adds namespace to all resources.
 namespace: node-feature-discovery-operator
 
@@ -72,4 +77,3 @@ vars:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
-

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: kube-rbac-proxy:latest
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -24,4 +24,3 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: kube-rbac-proxy:latest
+        image: kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
According to https://github.com/kubernetes-sigs/node-feature-discovery-operator/blob/b5efc6fb4b0bec190232ab47ac6fd687934d730d/docs/get-started/quick-start.md#L18

IMAGE_TAG could be configured for changing deploy image and tag, but not in the makefile, so I updated it.

Also, I add an extra variable `IMAGE_TAG_RBAC_PROXY`, ` gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0` by default, for the rbac proxy image and tag, so that we could change it when deploying.

I noticed there is both `$(shell pwd)` and `$(PROJECT_DIR)` in the Makefile, it may cause confusion, so that I changed them to a uniq `$(PROJECT_DIR)`