### PR TITLE
Add BASE_IMAGE_FULL build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-# Build the manager binary
+ARG BASE_IMAGE_FULL
+# Build the manager biinary
 FROM golang:1.16.6-buster as builder
 
 WORKDIR /workspace
@@ -14,7 +15,7 @@ COPY . .
 RUN make build
 
 # Create production image for running the operator
-FROM registry.access.redhat.com/ubi8/ubi
+FROM ${BASE_IMAGE_FULL}
 COPY --from=builder /workspace/node-feature-discovery-operator /
 
 RUN mkdir -p /opt/nfd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16.3-buster as builder
+FROM golang:1.16.6-buster as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ IMAGE_EXTRA_TAG_NAMES ?=
 IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG := $(IMAGE_REPO):$(IMAGE_TAG_NAME)
 IMAGE_EXTRA_TAGS := $(foreach tag,$(IMAGE_EXTRA_TAG_NAMES),$(IMAGE_REPO):$(tag))
+BASE_IMAGE_FULL ?= debian:buster-slim
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
@@ -156,6 +157,7 @@ generate: controller-gen
 # Build the docker image
 image:
 	$(IMAGE_BUILD_CMD) -t $(IMAGE_TAG) \
+		--build-arg BASE_IMAGE_FULL=$(BASE_IMAGE_FULL) \
 		$(foreach tag,$(IMAGE_EXTRA_TAGS),-t $(tag)) \
 		$(IMAGE_BUILD_EXTRA_OPTS) ./
 


### PR DESCRIPTION
This patch :
- Bumps base go image to 1.16.6
- updates second stage image to be consistent with NFD via build args