### PR TITLE
rbac: grant node/status update permission to manager and master

### DIFF
--- a/build/assets/master/0200_clusterrole.yaml
+++ b/build/assets/master/0200_clusterrole.yaml
@@ -8,8 +8,8 @@ rules:
   resources:
   - pods
   - nodes
+  - nodes/status
   verbs:
   - get
   - patch
   - update
-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -105,6 +104,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
after https://github.com/kubernetes-sigs/node-feature-discovery-operator/pull/77 merged, NFD operator can create resources labels, it will need this RBAC permission to update the node resources.