### PR TITLE
Use apimachinery error library to check for missing nfd instance

### DIFF
--- a/controllers/nodefeaturediscovery_controller.go
+++ b/controllers/nodefeaturediscovery_controller.go
@@ -22,9 +22,9 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/cri-api/pkg/errors"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -124,7 +124,7 @@ func (r *NodeFeatureDiscoveryReconciler) Reconcile(ctx context.Context, req ctrl
 	// Error reading the object - requeue the request.
 	if err != nil {
 		// handle deletion of resource
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue


### PR DESCRIPTION
The existing error checking library in the cri-api package was used to check for the case where the NFD instance is deleted. However, this error checking library is used for GRPC specific errors, not for errors related to the `metav1` package. The `metav1` package is used by various k8s resources (e.g., DaemonSet, Service, etc.), and thus, we should be checking for `metav1` problems, not GRPC problems.