### PR TITLE
Replace all logging methods with klogv2, if they do not use klog

### DIFF
--- a/controllers/nodefeaturediscovery_controller.go
+++ b/controllers/nodefeaturediscovery_controller.go
@@ -19,60 +19,58 @@ package controllers
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nfdv1 "github.com/kubernetes-sigs/node-feature-discovery-operator/api/v1"
 )
 
-// log is used to set the logger with a name that describes the actions of
-// functions and arguments in this file
-var log = logf.Log.WithName("controller_nodefeaturediscovery")
-
 // nfd is an NFD object that will be used to initialize the NFD operator
 var nfd NFD
 
-// NodeFeatureDiscoveryReconciler reconciles a NodeFeatureDiscovery object
-type NodeFeatureDiscoveryReconciler struct {
-
-	// Client interface to communicate with the API server. Reconciler needs this for
-	// fetching objects.
-	client.Client
-
-	// Log is used to log the reconciliation. Every controller needs this.
-	Log logr.Logger
-
-	// Scheme is used by the kubebuilder library to set OwnerReferences. Every
-	// controller needs this.
-	Scheme *runtime.Scheme
-
-	// Recorder defines interfaces for working with OCP event recorders. This
-	// field is needed by the operator in order for the operator to write events.
-	Recorder record.EventRecorder
+// NodeFeatureDiscoveryLogger is a dummy logger struct that is used with
+// the NodeFeatureDiscoveryReconciler to initiate a logger.
+type NodeFeatureDiscoveryLogger struct {
 }
 
-// SetupWithManager sets up the controller with a specified manager responsible for
-// initializing shared dependencies (like caches and clients)
+func (log *NodeFeatureDiscoveryLogger) Info(args ...interface{}) {
+	klog.Info(args)
+}
+
+func (log *NodeFeatureDiscoveryLogger) Infof(format string, args ...interface{}) {
+	klog.Infof(format, args)
+}
+
+func (log *NodeFeatureDiscoveryLogger) Error(args ...interface{}) {
+	klog.Error(args)
+}
+
+// NodeFeatureDiscoveryReconciler reconciles a NodeFeatureDiscovery object
+type NodeFeatureDiscoveryReconciler struct {
+	client.Client
+	Log       NodeFeatureDiscoveryLogger
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
+	AssetsDir string
+}
+
+// SetupWithManager sets up the controller with the Manager.
 func (r *NodeFeatureDiscoveryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
-	// The predicate package is used by the controller to filter events before
-	// they are sent to event handlers. Use it to initate the reconcile loop only
-	// on a spec change of the runtime object.
+	// we want to initate reconcile loop only on spec change of the object
 	p := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return validateUpdateEvent(&e)
+			return r.validateUpdateEvent(&e)
 		},
 	}
 
@@ -89,15 +87,13 @@ func (r *NodeFeatureDiscoveryReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		Complete(r)
 }
 
-// validateUpdateEvent looks at an update event and returns true or false
-// depending on whether the update event has runtime objects to update.
-func validateUpdateEvent(e *event.UpdateEvent) bool {
+func (r *NodeFeatureDiscoveryReconciler) validateUpdateEvent(e *event.UpdateEvent) bool {
 	if e.ObjectOld == nil {
-		klog.Error("Update event has no old runtime object to update")
+		r.Log.Error("Update event has no old runtime object to update")
 		return false
 	}
 	if e.ObjectNew == nil {
-		klog.Error("Update event has no new runtime object for update")
+		r.Log.Error("Update event has no new runtime object for update")
 		return false
 	}
 
@@ -133,25 +129,21 @@ func validateUpdateEvent(e *event.UpdateEvent) bool {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims
-// to move the current state of the cluster closer to the desired state.
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
 func (r *NodeFeatureDiscoveryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = r.Log.WithValues("nodefeaturediscovery", req.NamespacedName)
 
 	// Fetch the NodeFeatureDiscovery instance on the cluster
 	r.Log.Info("Fetch the NodeFeatureDiscovery instance")
 	instance := &nfdv1.NodeFeatureDiscovery{}
 	err := r.Get(ctx, req.NamespacedName, instance)
-
-	// If an error occurs because "r.Get" cannot get the NFD instance
-	// (e.g., due to timeouts, aborts, etc. defined by ctx), the
-	// request likely needs to be requeued.
+	// Error reading the object - requeue the request.
 	if err != nil {
 		// handle deletion of resource
 		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup
-			// logic use finalizers. Return and don't requeue.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
 			r.Log.Info("resource has been deleted", "req", req.Name, "got", instance.Name)
 			return ctrl.Result{Requeue: false}, nil
 		}

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -30,6 +30,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// Used for logging purposes
+var r NodeFeatureDiscoveryReconciler
+
 type controlFunc []func(n NFD) (ResourceStatus, error)
 
 // ResourceStatus defines the status of the resource as being
@@ -69,18 +72,17 @@ func Namespace(n NFD) (ResourceStatus, error) {
 
 	// found states if the Namespace was found
 	found := &corev1.Namespace{}
-	logger := log.WithValues("Namespace", obj.Name, "Namespace", "Cluster")
 
 	// Look for the Namespace to see if it exists, and if so, check if
 	// it's Ready/NotReady. If the Namespace does not exist, then
 	// attempt to create it
-	logger.Info("Looking for")
+	r.Log.Info("Looking for Namespace '", obj.Name, "'")
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating ")
+		r.Log.Info("Not found, creating ")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -88,7 +90,7 @@ func Namespace(n NFD) (ResourceStatus, error) {
 		return NotReady, err
 	}
 
-	logger.Info("Found, skipping update")
+	r.Log.Info("Found, skipping update")
 
 	return Ready, nil
 }
@@ -109,9 +111,8 @@ func ServiceAccount(n NFD) (ResourceStatus, error) {
 
 	// found states if the ServiceAccount was found
 	found := &corev1.ServiceAccount{}
-	logger := log.WithValues("ServiceAccount", obj.Name, "Namespace", obj.Namespace)
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for ServiceAccount '", obj.Name, "' in Namespace '", obj.Namespace, "'")
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -126,10 +127,10 @@ func ServiceAccount(n NFD) (ResourceStatus, error) {
 	// attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating ")
+		r.Log.Info("Not found, creating ")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -137,7 +138,7 @@ func ServiceAccount(n NFD) (ResourceStatus, error) {
 		return NotReady, err
 	}
 
-	logger.Info("Found, skipping update")
+	r.Log.Info("Found, skipping update")
 
 	return Ready, nil
 }
@@ -155,19 +156,18 @@ func ClusterRole(n NFD) (ResourceStatus, error) {
 
 	// found states if the ClusterRole was found
 	found := &rbacv1.ClusterRole{}
-	logger := log.WithValues("ClusterRole", obj.Name, "Namespace", obj.Namespace)
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for ClusterRole '", obj.Name, "'")
 
 	// Look for the ClusterRole to see if it exists, and if so, check
 	// if it's Ready/NotReady. If the ClusterRole does not exist, then
 	// attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating")
+		r.Log.Info("Not found, creating")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -176,7 +176,7 @@ func ClusterRole(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the ClusterRole, let's attempt to update it
-	logger.Info("Found, updating")
+	r.Log.Info("Found, updating")
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -198,23 +198,22 @@ func ClusterRoleBinding(n NFD) (ResourceStatus, error) {
 
 	// found states if the ClusterRoleBinding was found
 	found := &rbacv1.ClusterRoleBinding{}
-	logger := log.WithValues("ClusterRoleBinding", obj.Name, "Namespace", obj.Namespace)
 
 	// It is also assumed that our ClusterRoleBinding has a defined
 	// Namespace
 	obj.Subjects[0].Namespace = n.ins.GetNamespace()
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for ClusterRoleBinding '", obj.Name, "'")
 
 	// Look for the ClusterRoleBinding to see if it exists, and if so,
 	// check if it's Ready/NotReady. If the ClusterRoleBinding does not
 	// exist, then attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating")
+		r.Log.Info("Not found, creating")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -223,7 +222,7 @@ func ClusterRoleBinding(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the ClusterRoleBinding, let's attempt to update it
-	logger.Info("Found, updating")
+	r.Log.Info("Found, updating")
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -248,9 +247,8 @@ func Role(n NFD) (ResourceStatus, error) {
 
 	// found states if the Role was found
 	found := &rbacv1.Role{}
-	logger := log.WithValues("Role", obj.Name, "Namespace", obj.Namespace)
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for Role '", obj.Name, "' in Namespace '", obj.Namespace, "'")
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -264,10 +262,10 @@ func Role(n NFD) (ResourceStatus, error) {
 	// Ready/NotReady. If the Role does not exist, then attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating")
+		r.Log.Info("Not found, creating")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -276,7 +274,7 @@ func Role(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the Role, let's attempt to update it
-	logger.Info("Found, updating")
+	r.Log.Info("Found, updating")
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -302,9 +300,8 @@ func RoleBinding(n NFD) (ResourceStatus, error) {
 
 	// found states if the RoleBinding was found
 	found := &rbacv1.RoleBinding{}
-	logger := log.WithValues("RoleBinding", obj.Name, "Namespace", obj.Namespace)
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for RoleBinding", obj.Name, "in Namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -318,10 +315,10 @@ func RoleBinding(n NFD) (ResourceStatus, error) {
 	// to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating")
+		r.Log.Info("Not found, creating")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -330,7 +327,7 @@ func RoleBinding(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the RoleBinding, let's attempt to update it
-	logger.Info("Found, updating")
+	r.Log.Info("Found, updating")
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -359,9 +356,8 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 
 	// found states if the ConfigMap was found
 	found := &corev1.ConfigMap{}
-	logger := log.WithValues("ConfigMap", obj.Name, "Namespace", obj.Namespace)
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for ConfigMap '", obj.Name, "' in Namespace '", obj.Namespace, "'")
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -376,10 +372,10 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 	// it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating")
+		r.Log.Info("Not found, creating")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -388,7 +384,7 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the ConfigMap, let's attempt to update it
-	logger.Info("Found, updating")
+	r.Log.Info("Found, updating")
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -462,9 +458,8 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 
 	// found states if the DaemonSet was found
 	found := &appsv1.DaemonSet{}
-	logger := log.WithValues("DaemonSet", obj.Name, "Namespace", obj.Namespace)
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for DaemonSet '", obj.Name, "' in Namespace '", obj.Namespace, "'")
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -479,10 +474,10 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 	// create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating")
+		r.Log.Info("Not found, creating")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -491,7 +486,7 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the DaemonSet, let's attempt to update it
-	logger.Info("Found, updating")
+	r.Log.Info("Found, updating")
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -528,9 +523,8 @@ func Service(n NFD) (ResourceStatus, error) {
 
 	// found states if the Service was found
 	found := &corev1.Service{}
-	logger := log.WithValues("Service", obj.Name, "Namespace", obj.Namespace)
 
-	logger.Info("Looking for")
+	r.Log.Info("Looking for Service '", obj.Name, "' in Namespace '", obj.Namespace, "'")
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -545,10 +539,10 @@ func Service(n NFD) (ResourceStatus, error) {
 	// it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Not found, creating")
+		r.Log.Info("Not found, creating")
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			logger.Info("Couldn't create")
+			r.Log.Info("Couldn't create")
 			return NotReady, err
 		}
 		return Ready, nil
@@ -556,7 +550,7 @@ func Service(n NFD) (ResourceStatus, error) {
 		return NotReady, err
 	}
 
-	logger.Info("Found, updating")
+	r.Log.Info("Found, updating")
 
 	// Copy the Service object
 	required := obj.DeepCopy()

--- a/controllers/nodefeaturediscovery_resources.go
+++ b/controllers/nodefeaturediscovery_resources.go
@@ -148,7 +148,7 @@ func addResourcesControls(path string) (Resources, controlFunc) {
 			ctrl = append(ctrl, Service)
 
 		default:
-			log.Info("Unknown Resource: ", "Kind", kind)
+			r.Log.Infof("Unknown Resource: ", "Kind", kind)
 		}
 
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,13 @@ module github.com/kubernetes-sigs/node-feature-discovery-operator
 go 1.16
 
 require (
-	github.com/go-logr/logr v0.3.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/custom-resource-status v0.0.0-20210221154447-420d9ecf2a00
 	k8s.io/api v0.20.4
 	k8s.io/apimachinery v0.20.4
 	k8s.io/client-go v0.20.4
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.9.0
 	k8s.io/kubectl v0.20.4
 	sigs.k8s.io/controller-runtime v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,9 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v0.3.0 h1:q4c+kbcR0d5rSurhBR8dIgieOaYpXtsdTYfx22Cu6rs=
 github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
+github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.2.0 h1:v6Ji8yBW77pva6NkJKQdHLAJKrIJKRHz0RXwPqCHSR4=
 github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNVPunU=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
@@ -821,13 +822,13 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/klog v0.3.1 h1:RVgyDHY/kFKtLqh67NvEWIgkMneNoIrdkN0CxDSQc68=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
-k8s.io/klog/v2 v2.4.0 h1:7+X0fUguPyrKEC4WjH8iGDg3laWgMo5tMnRTIGTTxGQ=
 k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
+k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
+k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
 k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=

--- a/main.go
+++ b/main.go
@@ -97,7 +97,6 @@ func main() {
 
 	if err = (&controllers.NodeFeatureDiscoveryReconciler{
 		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NodeFeatureDiscovery"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeFeatureDiscovery")


### PR DESCRIPTION
Create a 'NodeFeatureDiscoveryLogger' object that is a wrapper
around klog itself. By using a wrapper and only using the new
'r.Log.*", we can ensure that the logging libraries used are
consistent across all files, and we can also ensure that it is easy
to change the logging library from klog to another logging library,
if that is desired in the future.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>
Co-Authored-by: Courtney Pacheco <cpacheco@redhat.com>