### PR TITLE
docs: link to correct version of operand docs

### DIFF
--- a/docs/_includes/templates/sidebar.liquid
+++ b/docs/_includes/templates/sidebar.liquid
@@ -15,7 +15,7 @@
             {% include templates/toctree.liquid %}
 
             {% comment %} cross-project reference to main nfd {% endcomment %}
-            <a class="caption d-block text-uppercase no-wrap px-2 py-0" href="https://kubernetes-sigs.github.io/node-feature-discovery">
+            <a class="caption d-block text-uppercase no-wrap px-2 py-0" href="https://kubernetes-sigs.github.io/node-feature-discovery/{{ site.operand_version }}">
                 Node Feature Discovery
             </a>
         </div>


### PR DESCRIPTION
Change the sidebar link to NFD (operand) documentation to point to the
version fixed in the docs config (and not automatically to the latest
release). This makes sure that docs of older releases point to an
operand version that they were tested with.