### PR TITLE
scripts/test-infra: bump golangci-lint to v1.45.2

### DIFF
--- a/scripts/test-infra/verify.sh
+++ b/scripts/test-infra/verify.sh
@@ -2,7 +2,7 @@
 
 # Install deps
 gobinpath="$(go env GOPATH)/bin"
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v1.42.1
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$gobinpath" v1.45.2
 export PATH=$PATH:$gobinpath
 
 # Run verify steps


### PR DESCRIPTION
Supports golang v1.18.