### PR TITLE
clusterserviceversion: fix nfd cr example

### DIFF
--- a/config/manifests/bases/nfd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd-operator.clusterserviceversion.yaml
@@ -15,7 +15,6 @@ metadata:
             "operand": {
               "image": "gcr.io/k8s-staging-nfd/node-feature-discovery:master",
               "imagePullPolicy": "Always",
-              "namespace": "node-feature-discovery-operator",
               "servicePort": 12000
             },
             "workerConfig": {


### PR DESCRIPTION
Remove the invalid namespace field from the embedded
NodeFeatureDiscovery example CR. The namespace field was dropped in
v0.4.0.