### PR TITLE
build/assets comply to restricted pod security level

### DIFF
--- a/build/assets/master/0400_master_deployment.yaml
+++ b/build/assets/master/0400_master_deployment.yaml
@@ -56,12 +56,14 @@ spec:
             - "nfd-master"
           args: []
           securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
             allowPrivilegeEscalation: false
             capabilities:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-            runAsNonRoot: true  
           volumeMounts: []
           livenessProbe:
             exec:

--- a/build/assets/worker/05_worker_ds.yaml
+++ b/build/assets/worker/05_worker_ds.yaml
@@ -58,6 +58,9 @@ spec:
               mountPath: "/etc/kubernetes/node-feature-discovery/features.d"
           securityContext:
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,6 +10,13 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         image: kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,6 +26,9 @@ spec:
         - name: manager
           securityContext:
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]


### PR DESCRIPTION
By default pod security admission level is going to be `restricted` in most deployments. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```bash
  1 nfd-master would violate PodSecurity "restricted:latest": runAsNonRoot != true (pod or container "nfd-master" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "nfd-master" must set securityContext.seccompP    rofile.type to "RuntimeDefault" or "Localhost")
  2 nfd-worker would violate PodSecurity "restricted:latest": host namespaces (hostNetwork=true), hostPath volumes (volumes "host-boot", "host-os-release", "host-sys", "host-usr-lib", "host-usr-src", "nfd-hooks", "nfd-features"), restrict    ed volume types (volumes "host-boot", "host-os-release", "host-sys", "host-usr-lib", "host-usr-src", "nfd-hooks", "nfd-features" use restricted volume type "hostPath"), runAsNonRoot != true (pod or container "nfd-worker" must set secu    rityContext.runAsNonRoot=true), seccompProfile (pod or container "nfd-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  3 daemonsets would violate PodSecurity "restricted:latest": host namespaces (hostNetwork=true), hostPath volumes (volumes "host-boot", "host-os-release", "host-sys", "host-usr-lib", "host-usr-src", "nfd-hooks", "nfd-features"), restrict    ed volume types (volumes "host-boot", "host-os-release", "host-sys", "host-usr-lib", "host-usr-src", "nfd-hooks", "nfd-features" use restricted volume type "hostPath"), runAsNonRoot != true (pod or container "nfd-worker" must set secu    rityContext.runAsNonRoot=true), seccompProfile (pod or container "nfd-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  4 daemonsets would violate PodSecurity "restricted:latest": runAsNonRoot != true (pod or container "nfd-master" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "nfd-master" must set securityContext.seccompP    rofile.type to "RuntimeDefault" or "Localhost")
  5 nfd-controller-manager would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "kube-    rbac-proxy" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "kube-rbac-proxy", "manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "kube-rbac-proxy", "m    anager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  6 deployments would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "kube-rbac-proxy"     must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "kube-rbac-proxy", "manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "kube-rbac-proxy", "manager" mus    t set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  7 replicasets would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "kube-rbac-proxy"     must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "kube-rbac-proxy", "manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "kube-rbac-proxy", "manager" mus    t set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost") 
  8 pods would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "kube-rbac-proxy" must s    et securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "kube-rbac-proxy", "manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "kube-rbac-proxy", "manager" must set s    ecurityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  9 pods would violate PodSecurity "restricted:latest": host namespaces (hostNetwork=true), hostPath volumes (volumes "host-boot", "host-os-release", "host-sys", "host-usr-lib", "host-usr-src", "nfd-hooks", "nfd-features"), restricted vol    ume types (volumes "host-boot", "host-os-release", "host-sys", "host-usr-lib", "host-usr-src", "nfd-hooks", "nfd-features" use restricted volume type "hostPath"), runAsNonRoot != true (pod or container "nfd-worker" must set securityCo    ntext.runAsNonRoot=true), seccompProfile (pod or container "nfd-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
 10 pods would violate PodSecurity "restricted:latest": runAsNonRoot != true (pod or container "nfd-master" must set securityContext.runAsNonRoot=true)
 11 pods would violate PodSecurity "restricted:latest": runAsNonRoot != true (pod or containers "kube-rbac-proxy", "elasticsearch-operator" must set securityContext.runAsNonRoot=true) 

```


Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>