### PR TITLE
Fix logging with format specifiers using klog.Info

### DIFF
--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -79,7 +79,7 @@ func ServiceAccount(n NFD) (ResourceStatus, error) {
 	// found states if the ServiceAccount was found
 	found := &corev1.ServiceAccount{}
 
-	klog.Info("Looking for ServiceAccount %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for ServiceAccount", "name", obj.Name, "namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -94,10 +94,10 @@ func ServiceAccount(n NFD) (ResourceStatus, error) {
 	// attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("ServiceAccount %q not found, creating", obj.Name)
+		klog.InfoS("ServiceAccount not found, creating", "name", obj.Name)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create ServiceAccount %q", obj.Name)
+			klog.ErrorS(err, "Couldn't create ServiceAccount", "name", obj.Name)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -105,7 +105,7 @@ func ServiceAccount(n NFD) (ResourceStatus, error) {
 		return NotReady, err
 	}
 
-	klog.Info("Found ServiceAccount %q in Namespace %q, skipping update", obj.Name, obj.Namespace)
+	klog.InfoS("Found ServiceAccount, skipping update", "name", obj.Name, "namespace", obj.Namespace)
 
 	return Ready, nil
 }
@@ -129,17 +129,17 @@ func ClusterRole(n NFD) (ResourceStatus, error) {
 	// found states if the ClusterRole was found
 	found := &rbacv1.ClusterRole{}
 
-	klog.Info("Looking for ClusterRole %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for ClusterRole", "name", obj.Name, "namespace", obj.Namespace)
 
 	// Look for the ClusterRole to see if it exists, and if so, check
 	// if it's Ready/NotReady. If the ClusterRole does not exist, then
 	// attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("ClusterRole %q not found, creating", obj.Name)
+		klog.InfoS("ClusterRole not found, creating", "name", obj.Name)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create ClusterRole %q", obj.Name)
+			klog.ErrorS(err, "Couldn't create ClusterRole", "name", obj.Name)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -148,7 +148,7 @@ func ClusterRole(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the ClusterRole, let's attempt to update it
-	klog.Info("ClusterRole found, updating", obj.Name)
+	klog.InfoS("ClusterRole found, updating", "name", obj.Name)
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -179,17 +179,17 @@ func ClusterRoleBinding(n NFD) (ResourceStatus, error) {
 	// Namespace
 	obj.Subjects[0].Namespace = n.ins.GetNamespace()
 
-	klog.Info("Looking for ClusterRoleBinding %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for ClusterRoleBinding", "name", obj.Name, "namespace", obj.Namespace)
 
 	// Look for the ClusterRoleBinding to see if it exists, and if so,
 	// check if it's Ready/NotReady. If the ClusterRoleBinding does not
 	// exist, then attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("ClusterRoleBinding %q not found in Namespace %q, creating", obj.Name, obj.Namespace)
+		klog.InfoS("ClusterRoleBinding not found, creating", "name", obj.Name, "namespace", obj.Namespace)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create ClusterRoleBinding %q in Namespace %q", obj.Name, obj.Namespace)
+			klog.ErrorS(err, "Couldn't create ClusterRoleBinding", "name", obj.Name, "namespace", obj.Namespace)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -198,7 +198,7 @@ func ClusterRoleBinding(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the ClusterRoleBinding, let's attempt to update it
-	klog.Info("ClusterRoleBinding %q found in Namespace %q, updating", obj.Name, obj.Namespace)
+	klog.InfoS("ClusterRoleBinding found, updating", "name", obj.Name, "namespace", obj.Namespace)
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -223,7 +223,7 @@ func Role(n NFD) (ResourceStatus, error) {
 	// found states if the Role was found
 	found := &rbacv1.Role{}
 
-	klog.Info("Looking for Role %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for Role", "name", obj.Name, "namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -237,10 +237,10 @@ func Role(n NFD) (ResourceStatus, error) {
 	// Ready/NotReady. If the Role does not exist, then attempt to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("Role %q not found in Namespace %q, creating", obj.Name, obj.Namespace)
+		klog.InfoS("Role not found, creating", "name", obj.Name, "namespace", obj.Namespace)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create Role %q in Namespace %q", obj.Name, obj.Namespace)
+			klog.ErrorS(err, "Couldn't create Role", "name", obj.Name, "namespace", obj.Namespace)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -249,7 +249,7 @@ func Role(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the Role, let's attempt to update it
-	klog.Info("Found Role %q in Namespace %q, updating", obj.Name, obj.Namespace)
+	klog.InfoS("Found Role, updating", "name", obj.Name, "namespace", obj.Namespace)
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -275,7 +275,7 @@ func RoleBinding(n NFD) (ResourceStatus, error) {
 	// found states if the RoleBinding was found
 	found := &rbacv1.RoleBinding{}
 
-	klog.Info("Looking for RoleBinding %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for RoleBinding", "name", obj.Name, "namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -289,10 +289,10 @@ func RoleBinding(n NFD) (ResourceStatus, error) {
 	// to create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("RoleBinding %q not found in Namespace %q, creating", obj.Name, obj.Namespace)
+		klog.InfoS("RoleBinding not found, creating", "name", obj.Name, "namespace", obj.Namespace)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create RoleBinding %q in namespace %q", obj.Name, obj.Namespace)
+			klog.ErrorS(err, "Couldn't create RoleBinding", "name", obj.Name, "namespace", obj.Namespace)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -301,7 +301,7 @@ func RoleBinding(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the RoleBinding, let's attempt to update it
-	klog.Info("RoleBinding %q found in Namespace %q, updating", obj.Name, obj.Namespace)
+	klog.InfoS("RoleBinding found, updating", "name", obj.Name, "namespace", obj.Namespace)
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -330,7 +330,7 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 	// found states if the ConfigMap was found
 	found := &corev1.ConfigMap{}
 
-	klog.Info("Looking for ConfigMap %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for ConfigMap", "name", obj.Name, "namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -345,10 +345,10 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 	// it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("ConfigMap %q not found in Namespace %q, creating", obj.Name, obj.Namespace)
+		klog.InfoS("ConfigMap not found, creating", "name", obj.Name, "namespace", obj.Namespace)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create ConfigMap %q in Namespace %q", obj.Name, obj.Namespace)
+			klog.ErrorS(err, "Couldn't create ConfigMap", "name", obj.Name, "namespace", obj.Namespace)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -357,7 +357,7 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the ConfigMap, let's attempt to update it
-	klog.Info("Found ConfigMap %q in Namespace %q, updating", obj.Name, obj.Namespace)
+	klog.InfoS("Found ConfigMap, updating", "name", obj.Name, "namespace", obj.Namespace)
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -396,7 +396,7 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 	// found states if the DaemonSet was found
 	found := &appsv1.DaemonSet{}
 
-	klog.Info("Looking for Daemonset %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for Daemonset", "name", obj.Name, "namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -411,10 +411,10 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 	// create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("Daemonset %q in Namespace %q not found, creating", obj.Name, obj.Namespace)
+		klog.InfoS("Daemonset not found, creating", "name", obj.Name, "namespace", obj.Namespace)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create Daemonset %q in Namespace %q", obj.Name, obj.Namespace)
+			klog.ErrorS(err, "Couldn't create Daemonset", "name", obj.Name, "namespace", obj.Namespace)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -423,7 +423,7 @@ func DaemonSet(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the DaemonSet, let's attempt to update it
-	klog.Info("Daemonset %q in Namespace %q found, updating", obj.Name, obj.Namespace)
+	klog.InfoS("Daemonset found, updating", "name", obj.Name, "namespace", obj.Namespace)
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -492,7 +492,7 @@ func Deployment(n NFD) (ResourceStatus, error) {
 	// found states if the Deployment was found
 	found := &appsv1.Deployment{}
 
-	klog.Info("Looking for Deployment %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for Deployment", "name", obj.Name, "namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -507,10 +507,10 @@ func Deployment(n NFD) (ResourceStatus, error) {
 	// create it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("Deployment %q in Namespace %q not found, creating", obj.Name, obj.Namespace)
+		klog.InfoS("Deployment not found, creating", "name", obj.Name, "namespace", obj.Namespace)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create Deployment %q in Namespace %q", obj.Name, obj.Namespace)
+			klog.ErrorS(err, "Couldn't create Deployment", "name", obj.Name, "namespace", obj.Namespace)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -519,7 +519,7 @@ func Deployment(n NFD) (ResourceStatus, error) {
 	}
 
 	// If we found the Deployment, let's attempt to update it
-	klog.Info("Deployment %q in Namespace %q found, updating", obj.Name, obj.Namespace)
+	klog.InfoS("Deployment found, updating", "name", obj.Name, "namespace", obj.Namespace)
 	err = n.rec.Client.Update(context.TODO(), &obj)
 	if err != nil {
 		return NotReady, err
@@ -556,7 +556,7 @@ func Service(n NFD) (ResourceStatus, error) {
 	// found states if the Service was found
 	found := &corev1.Service{}
 
-	klog.Info("Looking for Service %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Looking for Service", "name", obj.Name, "namespace", obj.Namespace)
 
 	// SetControllerReference sets the owner as a Controller OwnerReference
 	// and is used for garbage collection of the controlled object. It is
@@ -571,10 +571,10 @@ func Service(n NFD) (ResourceStatus, error) {
 	// it
 	err := n.rec.Client.Get(context.TODO(), types.NamespacedName{Namespace: obj.Namespace, Name: obj.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
-		klog.Info("Service %q in Namespace %q not found, creating", obj.Name, obj.Namespace)
+		klog.InfoS("Service not found, creating", "name", obj.Name, "namespace", obj.Namespace)
 		err = n.rec.Client.Create(context.TODO(), &obj)
 		if err != nil {
-			klog.Info("Couldn't create Service %q in Namespace %q", obj.Name, obj.Namespace)
+			klog.ErrorS(err, "Couldb't create Service", "name", obj.Name, "namespace", obj.Namespace)
 			return NotReady, err
 		}
 		return Ready, nil
@@ -582,7 +582,7 @@ func Service(n NFD) (ResourceStatus, error) {
 		return NotReady, err
 	}
 
-	klog.Info("Found Service %q in Namespace %q", obj.Name, obj.Namespace)
+	klog.InfoS("Found Service", "name", obj.Name, "namespace", obj.Namespace)
 
 	// Copy the Service object
 	required := obj.DeepCopy()


### PR DESCRIPTION
This PR fixes logging when format specifiers are defined but [klog.Info ](https://pkg.go.dev/k8s.io/klog/v2#Info) is used. Instead, [klog.InfoS](https://pkg.go.dev/k8s.io/klog/v2#InfoS) (also [klog.ErrorS](https://pkg.go.dev/k8s.io/klog/v2#ErrorS)) are used to resolve the issue and follow the Kubernetes community [logging recommendations](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#how-to-log).

- https://pkg.go.dev/k8s.io/klog/v2#Info
- https://pkg.go.dev/k8s.io/klog/v2#InfoS
- https://pkg.go.dev/k8s.io/klog/v2#ErrorS

Example:

```
# obj.Name = foo
klog.Info("ServiceAccount %q not found, creating", obj.Name) => "ServiceAccount %q not found, creating foo"

klog.InfoS("ServiceAccount %q not found, creating", "name", obj.Name) => "ServiceAccount not found, creating" name="foo"
```

Signed-off-by: Michail Resvanis <mresvani@redhat.com>