### PR TITLE
Run local markdown tests inside an isolated container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ GO_CMD ?= go
 GO_FMT ?= gofmt
 CONTAINER_RUN_CMD ?= docker run -u "`id -u`:`id -g`"
 
-MDL ?= mdl
-
 # Docker base command for working with html documentation.
 # Use host networking because 'jekyll serve' is stupid enough to use the
 # same site url than the "host" it binds to. Thus, all the links will be
@@ -151,7 +149,12 @@ ci-lint:
 	golangci-lint run --timeout 5m0s
 
 mdlint:
-	find docs/ -path docs/vendor -prune -false -o -name '*.md' | xargs $(MDL) -s docs/mdl-style.rb
+	${CONTAINER_RUN_CMD} \
+	--rm \
+	--volume "${PWD}:/workdir:ro,z" \
+	--workdir /workdir \
+	ruby:slim \
+	/workdir/scripts/test-infra/mdlint.sh
 
 clean:
 	$(GO_CMD)  clean

--- a/scripts/test-infra/mdlint.sh
+++ b/scripts/test-infra/mdlint.sh
@@ -4,4 +4,4 @@
 gem install mdl -v 0.11.0
 
 # Run verify steps
-make mdlint
+find docs/ -path docs/vendor -prune -false -o -name '*.md' | xargs mdl -s docs/mdl-style.rb


### PR DESCRIPTION
When working on a patch that touches docs/, there is no way to test changes against markdown checks before submitting a PR. In fact, we have a makefile target mdlint but it has a prerequisite of having mdl installed on the developer machine. What do you think of swapping the tasks of mdlint Makefile target with scripts/test-infra/mdlint.sh script with minor modifications so that developer can just run make mdlint which calls scripts/test-infra/mdlint.sh and the tests get executed within a container. Once execution is completed the temporary container gets removed so that we don't have garbage collected. I've chosen [ruby:slim](https://hub.docker.com/layers/library/ruby/slim/images/sha256-2e3b4a4628fead83109e77fa6732e430cf9881e2d8cb3fa6148935e87ea4ea70?context=explore) image (70.39 MB), which is almost five times smaller than [ruby:2.7](https://hub.docker.com/layers/library/ruby/2.7/images/sha256-5a32f6abc3c485231580c241047954c9d857e208a65392a8bca7fbb1888d2ed6?context=explore) (321.36 MB) that [we use in our](https://github.com/kubernetes/test-infra/blob/6403fa097aec8093550c398ded1022bbf180e770/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits.yaml#L49) Prow tests.

Replication of https://github.com/kubernetes-sigs/node-feature-discovery/pull/882. Also, this is required because I've already changed the container image we use in https://github.com/kubernetes/test-infra/pull/27376 without adding these changes here.