### PR TITLE
[release-0.5] docs: fix operand version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ GO_CMD ?= go
 GO_FMT ?= gofmt
 CONTAINER_RUN_CMD ?= docker run -u "`id -u`:`id -g`"
 
-MDL ?= mdl
-
 # Docker base command for working with html documentation.
 # Use host networking because 'jekyll serve' is stupid enough to use the
 # same site url than the "host" it binds to. Thus, all the links will be
@@ -151,7 +149,12 @@ ci-lint:
 	golangci-lint run --timeout 5m0s
 
 mdlint:
-	find docs/ -path docs/vendor -prune -false -o -name '*.md' | xargs $(MDL) -s docs/mdl-style.rb
+	${CONTAINER_RUN_CMD} \
+	--rm \
+	--volume "${PWD}:/workdir:ro,z" \
+	--workdir /workdir \
+	ruby:slim \
+	/workdir/scripts/test-infra/mdlint.sh
 
 clean:
 	$(GO_CMD)  clean

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -53,4 +53,4 @@ release: v0.5.0
 # Container image which to point to in the documentation
 container_image: k8s.gcr.io/nfd/node-feature-discovery-operator:v0.5.0-minimal
 # Operand Node Feature Discovery documentation version
-operand_version: v0.11.0
+operand_version: v0.11

--- a/scripts/test-infra/mdlint.sh
+++ b/scripts/test-infra/mdlint.sh
@@ -4,4 +4,4 @@
 gem install mdl -v 0.11.0
 
 # Run verify steps
-make mdlint
+find docs/ -path docs/vendor -prune -false -o -name '*.md' | xargs mdl -s docs/mdl-style.rb


### PR DESCRIPTION
The operand_version parameter is supposed to point to a certain release branch, not to a specific tag.