### PR TITLE
Deprecation of package ioutil

### DIFF
--- a/controllers/nodefeaturediscovery_resources.go
+++ b/controllers/nodefeaturediscovery_resources.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -80,7 +79,7 @@ func getAssetsFrom(path string) []assetsFromFile {
 	// For each file in the 'files' list, read the file
 	// and store its contents in 'manifests'
 	for _, file := range files {
-		buffer, err := ioutil.ReadFile(file)
+		buffer, err := os.ReadFile(file)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
"io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (SA1019)go-staticcheck

https://github.com/go-critic/go-critic/issues/1019