### PR TITLE
dockerfile: builder image configurable through a Makefile variable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
+ARG BUILDER_IMAGE
 ARG BASE_IMAGE_FULL
 ARG BASE_IMAGE_MINIMAL
 # Build the manager biinary
-FROM golang:1.19.5-buster as builder
+FROM ${BUILDER_IMAGE} as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 GO_CMD ?= go
 GO_FMT ?= gofmt
+GO_VERSION := $(shell awk '/go /{print $$2}' go.mod|grep -v v)
 CONTAINER_RUN_CMD ?= docker run -u "`id -u`:`id -g`"
 
 # Docker base command for working with html documentation.
@@ -62,6 +63,7 @@ IMAGE_EXTRA_TAG_NAMES ?=
 IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG ?= $(IMAGE_REPO):$(IMAGE_TAG_NAME)
 IMAGE_EXTRA_TAGS := $(foreach tag,$(IMAGE_EXTRA_TAG_NAMES),$(IMAGE_REPO):$(tag))
+BUILDER_IMAGE ?= golang:$(GO_VERSION)-buster
 BASE_IMAGE_FULL ?= debian:buster-slim
 BASE_IMAGE_MINIMAL ?= gcr.io/distroless/base
 
@@ -173,6 +175,7 @@ generate: controller-gen
 image:
 	$(IMAGE_BUILD_CMD) -t $(IMAGE_TAG) \
 		--target full \
+		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		--build-arg BASE_IMAGE_FULL=$(BASE_IMAGE_FULL) \
 		--build-arg BASE_IMAGE_MINIMAL=$(BASE_IMAGE_MINIMAL) \
 		$(foreach tag,$(IMAGE_EXTRA_TAGS),-t $(tag)) \
@@ -181,6 +184,7 @@ image:
 image-minimal:
 	$(IMAGE_BUILD_CMD) -t $(IMAGE_TAG)-minimal \
 		--target minimal \
+		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		--build-arg BASE_IMAGE_FULL=$(BASE_IMAGE_FULL) \
 		--build-arg BASE_IMAGE_MINIMAL=$(BASE_IMAGE_MINIMAL) \
 		$(foreach tag,$(IMAGE_EXTRA_TAGS),-t $(tag)-minimal) \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 GO_CMD ?= go
 GO_FMT ?= gofmt
-GO_VERSION := $(shell awk '/go /{print $$2}' go.mod|grep -v v)
+GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod|head -n1)
 CONTAINER_RUN_CMD ?= docker run -u "`id -u`:`id -g`"
 
 # Docker base command for working with html documentation.


### PR DESCRIPTION
Switch over to the "non-point-release" version of the image. Now we always use the latest patch version of golang with latest security fixes, for example, without the need to manually bump the version after every point release.

This patch also makes the builder image configurable through a Makefile variable pointing to the go.mod go version, that way the go.mod file becomes the source of truth for the go version.