### PR TITLE
Dockerfile: define numeric user to run unprivileged  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ testbin/*
 *.swo
 *~
 .vscode/*
-node-feature-discovery-operator
+./node-feature-discovery-operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ FROM ${BASE_IMAGE_FULL} as full
 COPY --from=builder /workspace/node-feature-discovery-operator /
 COPY --from=builder /workspace/build/assets /opt/nfd
 
-RUN useradd nfd-operator
-USER nfd-operator
+# Run as unprivileged user
+USER 65534:65534
 
 ENTRYPOINT ["/node-feature-discovery-operator"]
 LABEL io.k8s.display-name="node-feature-discovery-operator"


### PR DESCRIPTION
This patch fix error:
```bash
Warning  Failed     65s (x7 over 2m21s)  kubelet            Error: container has runAsNonRoot and image has non-numeric user (nfd-operator), cannot verify user is non-root (pod: "node-feature-discovery-operator-controller-manager-6ccbd689t98z_node-feature-discovery-operator(89328c77-19c4-420d-8e09-61fca475630e)", container: manager)
```

By moving from named user `nfd-operator` to a numeric value user  `USER 65534:65534` 

Extra: define the generated `make build` binary path in gitignore to prevent future helm folders with same name to be ignored by git 