### PR TITLE
Update image registry to registry.k8s.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -25,8 +25,8 @@ Please do not remove items from the checklist
       `git push $VERSION`
       This will trigger prow to build and publish a staging container image
       `gcr.io/k8s-staging-nfd/node-feature-discovery-operator:$VERSION`
-- [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io), updating `k8s.gcr.io/images/k8s-staging-nfd/images.yaml` to promote the container image to production
-- [ ] Wait for the PR to be merged and verify that the image (`k8s.gcr.io/nfd/node-feature-discovery-operator:$VERSION`) is available.
+- [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io), updating `registry.k8s.io/images/k8s-staging-nfd/images.yaml` to promote the container image to production
+- [ ] Wait for the PR to be merged and verify that the image (`registry.k8s.io/nfd/node-feature-discovery-operator:$VERSION`) is available.
 - [ ] Write the change log into the [Github release info](https://github.com/kubernetes-sigs/node-feature-discovery-operator/releases).
 - [ ] Add a link to the tagged release in this issue.
 - [ ] Create a new bundle for the $VERSION release at https://github.com/k8s-operatorhub/community-operators 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ BUNDLE_IMG ?= controller-bundle:$(VERSION)
 IMAGE_BUILD_CMD ?= docker build
 IMAGE_PUSH_CMD ?= docker push
 IMAGE_BUILD_EXTRA_OPTS ?=
-IMAGE_REGISTRY ?= k8s.gcr.io/nfd
+IMAGE_REGISTRY ?= registry.k8s.io/nfd
 IMAGE_NAME := node-feature-discovery-operator
 IMAGE_TAG_NAME ?= $(VERSION)
 IMAGE_EXTRA_TAG_NAMES ?=
@@ -116,7 +116,7 @@ install: manifests kustomize
 uninstall: manifests kustomize
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
-clean-manifests = (cd config/manager && $(KUSTOMIZE) edit set image controller=k8s.gcr.io/nfd/node-feature-discovery-operator:0.4.2)
+clean-manifests = (cd config/manager && $(KUSTOMIZE) edit set image controller=registry.k8s.io/nfd/node-feature-discovery-operator:0.4.2)
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: kustomize

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,10 +13,10 @@ The process to release a new version of node-feature-discovery-operator is as fo
   `gcr.io/k8s-staging-nfd/node-feature-discovery-operator:$VERSION`
 - [ ] Do final release verification on the staging image
 - [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io),
-  updating `k8s.gcr.io/images/k8s-staging-nfd/images.yaml`, in order to promote
+  updating `registry.k8s.io/images/k8s-staging-nfd/images.yaml`, in order to promote
   the container image to production
 - [ ] Wait for the PR to be merged and verify that the image
-  (`k8s.gcr.io/nfd/node-feature-discovery-operator:$VERSION`) is available
+  (`registry.k8s.io/nfd/node-feature-discovery-operator:$VERSION`) is available
 - [ ] Write the change log into the
   [Github release info](https://github.com/kubernetes-sigs/node-feature-discovery-operator/releases).
 - [ ] Add a link to the tagged release in this issue

--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -69,7 +69,7 @@ type NodeFeatureDiscoverySpec struct {
 type OperandSpec struct {
 	// Image defines the image to pull for the
 	// NFD operand
-	// [defaults to k8s.gcr.io/nfd/node-feature-discovery]
+	// [defaults to registry.k8s.io/nfd/node-feature-discovery]
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9\-]+
 	Image string `json:"image,omitempty"`
 

--- a/bundle/manifests/nfd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nfd-operator.clusterserviceversion.yaml
@@ -64,7 +64,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: k8s.gcr.io/nfd/node-feature-discovery-operator:master
+    containerImage: registry.k8s.io/nfd/node-feature-discovery-operator:master
     createdAt: "2023-01-17T14:52:07Z"
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.
@@ -404,7 +404,7 @@ spec:
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
                   value: gcr.io/k8s-staging-nfd/node-feature-discovery:master
-                image: k8s.gcr.io/nfd/node-feature-discovery-operator:0.5.0-minimal
+                image: registry.k8s.io/nfd/node-feature-discovery-operator:0.5.0-minimal
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/bundle/manifests/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -59,7 +59,7 @@ spec:
                 properties:
                   image:
                     description: Image defines the image to pull for the NFD operand
-                      [defaults to k8s.gcr.io/nfd/node-feature-discovery]
+                      [defaults to registry.k8s.io/nfd/node-feature-discovery]
                     pattern: '[a-zA-Z0-9\-]+'
                     type: string
                   imagePullPolicy:

--- a/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -59,7 +59,7 @@ spec:
                 properties:
                   image:
                     description: Image defines the image to pull for the NFD operand
-                      [defaults to k8s.gcr.io/nfd/node-feature-discovery]
+                      [defaults to registry.k8s.io/nfd/node-feature-discovery]
                     pattern: '[a-zA-Z0-9\-]+'
                     type: string
                   imagePullPolicy:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: k8s.gcr.io/nfd/node-feature-discovery-operator
+  newName: registry.k8s.io/nfd/node-feature-discovery-operator
   newTag: 0.5.0

--- a/config/manifests/bases/nfd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: k8s.gcr.io/nfd/node-feature-discovery-operator:master
+    containerImage: registry.k8s.io/nfd/node-feature-discovery-operator:master
     createdAt: "2022-01-19T18:23:18Z"
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.


### PR DESCRIPTION
On the 3rd of April 2023, the old registry k8s.gcr.io will be frozen and no further images for Kubernetes and related subprojects will be pushed to the old registry.