### PR TITLE
set permissions for the refactored controller

### DIFF
--- a/config/crd/bases/nfd.k8s-sigs.io_nodefeatures.yaml
+++ b/config/crd/bases/nfd.k8s-sigs.io_nodefeatures.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: nodefeatures.nfd.k8s-sigs.io
+spec:
+  group: nfd.k8s-sigs.io
+  names:
+    kind: NodeFeature
+    listKind: NodeFeatureList
+    plural: nodefeatures
+    singular: nodefeature
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeFeature resource holds the features discovered for one node
+          in the cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeFeatureSpec describes a NodeFeature object.
+            properties:
+              features:
+                description: Features is the full "raw" features data that has been
+                  discovered.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      description: AttributeFeatureSet is a set of features having
+                        string value.
+                      properties:
+                        elements:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                    description: Attributes contains all the attribute-type features
+                      of the node.
+                    type: object
+                  flags:
+                    additionalProperties:
+                      description: FlagFeatureSet is a set of simple features only
+                        containing names without values.
+                      properties:
+                        elements:
+                          additionalProperties:
+                            description: Nil is a dummy empty struct for protobuf
+                              compatibility
+                            type: object
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                    description: Flags contains all the flag-type features of the
+                      node.
+                    type: object
+                  instances:
+                    additionalProperties:
+                      description: InstanceFeatureSet is a set of features each of
+                        which is an instance having multiple attributes.
+                      properties:
+                        elements:
+                          items:
+                            description: InstanceFeature represents one instance of
+                              a complex features, e.g. a device.
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            required:
+                            - attributes
+                            type: object
+                          type: array
+                      required:
+                      - elements
+                      type: object
+                    description: Instances contains all the instance-type features
+                      of the node.
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels is the set of node labels that are requested to
+                  be created.
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/config/crd/bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
+++ b/config/crd/bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
@@ -1,0 +1,221 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: nodefeaturerules.nfd.k8s-sigs.io
+spec:
+  group: nfd.k8s-sigs.io
+  names:
+    kind: NodeFeatureRule
+    listKind: NodeFeatureRuleList
+    plural: nodefeaturerules
+    singular: nodefeaturerule
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeFeatureRule resource specifies a configuration for feature-based
+          customization of node objects, such as node labeling.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeFeatureRuleSpec describes a NodeFeatureRule.
+            properties:
+              rules:
+                description: Rules is a list of node customization rules.
+                items:
+                  description: Rule defines a rule for node customization such as
+                    labeling.
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels to create if the rule matches.
+                      type: object
+                    labelsTemplate:
+                      description: LabelsTemplate specifies a template to expand for
+                        dynamically generating multiple labels. Data (after template
+                        expansion) must be keys with an optional value (<key>[=<value>])
+                        separated by newlines.
+                      type: string
+                    matchAny:
+                      description: MatchAny specifies a list of matchers one of which
+                        must match.
+                      items:
+                        description: MatchAnyElem specifies one sub-matcher of MatchAny.
+                        properties:
+                          matchFeatures:
+                            description: MatchFeatures specifies a set of matcher
+                              terms all of which must match.
+                            items:
+                              description: FeatureMatcherTerm defines requirements
+                                against one feature set. All requirements (specified
+                                as MatchExpressions) are evaluated against each element
+                                in the feature set.
+                              properties:
+                                feature:
+                                  type: string
+                                matchExpressions:
+                                  additionalProperties:
+                                    description: "MatchExpression specifies an expression
+                                      to evaluate against a set of input values. It
+                                      contains an operator that is applied when matching
+                                      the input and an array of values that the operator
+                                      evaluates the input against. \n NB: CreateMatchExpression
+                                      or MustCreateMatchExpression() should be used
+                                      for     creating new instances. NB: Validate()
+                                      must be called if Op or Value fields are modified
+                                      or if a new     instance is created from scratch
+                                      without using the helper functions."
+                                    properties:
+                                      op:
+                                        description: Op is the operator to be applied.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - InRegexp
+                                        - Exists
+                                        - DoesNotExist
+                                        - Gt
+                                        - Lt
+                                        - GtLt
+                                        - IsTrue
+                                        - IsFalse
+                                        type: string
+                                      value:
+                                        description: Value is the list of values that
+                                          the operand evaluates the input against.
+                                          Value should be empty if the operator is
+                                          Exists, DoesNotExist, IsTrue or IsFalse.
+                                          Value should contain exactly one element
+                                          if the operator is Gt or Lt and exactly
+                                          two elements if the operator is GtLt. In
+                                          other cases Value should contain at least
+                                          one element.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - op
+                                    type: object
+                                  description: MatchExpressionSet contains a set of
+                                    MatchExpressions, each of which is evaluated against
+                                    a set of input values.
+                                  type: object
+                              required:
+                              - feature
+                              - matchExpressions
+                              type: object
+                            type: array
+                        required:
+                        - matchFeatures
+                        type: object
+                      type: array
+                    matchFeatures:
+                      description: MatchFeatures specifies a set of matcher terms
+                        all of which must match.
+                      items:
+                        description: FeatureMatcherTerm defines requirements against
+                          one feature set. All requirements (specified as MatchExpressions)
+                          are evaluated against each element in the feature set.
+                        properties:
+                          feature:
+                            type: string
+                          matchExpressions:
+                            additionalProperties:
+                              description: "MatchExpression specifies an expression
+                                to evaluate against a set of input values. It contains
+                                an operator that is applied when matching the input
+                                and an array of values that the operator evaluates
+                                the input against. \n NB: CreateMatchExpression or
+                                MustCreateMatchExpression() should be used for     creating
+                                new instances. NB: Validate() must be called if Op
+                                or Value fields are modified or if a new     instance
+                                is created from scratch without using the helper functions."
+                              properties:
+                                op:
+                                  description: Op is the operator to be applied.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - InRegexp
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                                  - GtLt
+                                  - IsTrue
+                                  - IsFalse
+                                  type: string
+                                value:
+                                  description: Value is the list of values that the
+                                    operand evaluates the input against. Value should
+                                    be empty if the operator is Exists, DoesNotExist,
+                                    IsTrue or IsFalse. Value should contain exactly
+                                    one element if the operator is Gt or Lt and exactly
+                                    two elements if the operator is GtLt. In other
+                                    cases Value should contain at least one element.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - op
+                              type: object
+                            description: MatchExpressionSet contains a set of MatchExpressions,
+                              each of which is evaluated against a set of input values.
+                            type: object
+                        required:
+                        - feature
+                        - matchExpressions
+                        type: object
+                      type: array
+                    name:
+                      description: Name of the rule.
+                      type: string
+                    vars:
+                      additionalProperties:
+                        type: string
+                      description: Vars is the variables to store if the rule matches.
+                        Variables do not directly inflict any changes in the node
+                        object. However, they can be referenced from other rules enabling
+                        more complex rule hierarchies, without exposing intermediary
+                        output values as labels.
+                      type: object
+                    varsTemplate:
+                      description: VarsTemplate specifies a template to expand for
+                        dynamically generating multiple variables. Data (after template
+                        expansion) must be keys with an optional value (<key>[=<value>])
+                        separated by newlines.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - rules
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,11 +1,12 @@
 # This kustomization.yaml is not intended to be run by itself,
-# since it depends on service name and namespace that are out of this kustomize package.
+# since it depends on service name and namespace that are
+# out of this kustomize package.
 # It should be run by config/default
 resources:
 - bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
-- bases/nfd.kubernetes.io_v1alpha1_nodefeaturerules.yaml
+- bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
 - bases/node.k8s.io_v1alpha1_noderesourcetopologies.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+- bases/nfd.k8s-sigs.io_nodefeatures.yaml
 
 commonAnnotations:
   api-approved.kubernetes.io: "unapproved, experimental-only"
@@ -16,12 +17,12 @@ patchesStrategicMerge:
 #- patches/webhook_in_nodefeaturediscoveries.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable webhook, uncomment all
+# the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_nodefeaturediscoveries.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
-# the following config is for teaching kustomize how to do kustomization for CRDs.
+# the following config teaches kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
-

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -17,4 +17,3 @@ namespace:
 
 varReference:
 - path: metadata/annotations
-

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,13 +6,6 @@ images:
 # Adds namespace to all resources.
 namespace: node-feature-discovery-operator
 
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: nfd-
-
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: nfd-controller-manager
   namespace: node-feature-discovery-operator
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: nfd-controller-manager
   namespace: node-feature-discovery-operator
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,25 +2,25 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: nfd-controller-manager
   name: node-feature-discovery-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: nfd-controller-manager
   namespace: node-feature-discovery-operator
   labels:
     control-plane: controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: nfd-controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: nfd-controller-manager
     spec:
       containers:
         - name: manager

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,8 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+    control-plane: nfd-controller-manager
+  name: nfd-controller-manager-metrics-monitor
   namespace: node-feature-discovery-operator
 spec:
   endpoints:
@@ -13,5 +13,5 @@ spec:
       port: https
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: nfd-controller-manager
 

--- a/config/rbac/auth_proxy/client_clusterrole.yaml
+++ b/config/rbac/auth_proxy/client_clusterrole.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: nfd-metrics-reader
 rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-

--- a/config/rbac/auth_proxy/kustomization.yaml
+++ b/config/rbac/auth_proxy/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- client_clusterrole.yaml
+- role_binding.yaml
+- role.yaml
+- service.yaml

--- a/config/rbac/auth_proxy/role.yaml
+++ b/config/rbac/auth_proxy/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: proxy-role
+  name: nfd-proxy-role
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources:
@@ -11,4 +11,3 @@ rules:
   resources:
   - subjectaccessreviews
   verbs: ["create"]
-

--- a/config/rbac/auth_proxy/role_binding.yaml
+++ b/config/rbac/auth_proxy/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: node-feature-discovery-operator

--- a/config/rbac/auth_proxy/service.yaml
+++ b/config/rbac/auth_proxy/service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
+    control-plane: nfd-controller-manager
+  name: nfd-controller-manager-metrics-service
   namespace: node-feature-discovery-operator
 spec:
   ports:
@@ -11,5 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
-
+    control-plane: nfd-controller-manager

--- a/config/rbac/core/kustomization.yaml
+++ b/config/rbac/core/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- leader_election_role_binding.yaml
+- leader_election_role.yaml
+- manager_role_binding.yaml
+- manager_role.yaml

--- a/config/rbac/core/leader_election_role.yaml
+++ b/config/rbac/core/leader_election_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: nfd-leader-election-role
 rules:
 - apiGroups:
   - ""
@@ -71,4 +71,3 @@ rules:
   - '*'
   verbs:
   - '*'
-

--- a/config/rbac/core/leader_election_role_binding.yaml
+++ b/config/rbac/core/leader_election_role_binding.yaml
@@ -1,13 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: manager-rolebinding
+  name: nfd-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manager-role
+  kind: Role
+  name: nfd-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: default
   namespace: node-feature-discovery-operator
-

--- a/config/rbac/core/manager_role.yaml
+++ b/config/rbac/core/manager_role.yaml
@@ -1,0 +1,216 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: nfd-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - issuers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeaturerules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resourceNames:
+  - nfd-worker
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - update

--- a/config/rbac/core/manager_role.yaml.working
+++ b/config/rbac/core/manager_role.yaml.working
@@ -106,6 +106,7 @@ rules:
   - get
   - patch
   - update
+  - list
 - apiGroups:
   - ""
   resources:
@@ -150,6 +151,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - policy
   resourceNames:
@@ -214,3 +216,18 @@ rules:
   - create
   - get
   - update
+  - delete
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - list
+  - delete

--- a/config/rbac/core/manager_role_binding.yaml
+++ b/config/rbac/core/manager_role_binding.yaml
@@ -1,13 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: nfd-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: leader-election-role
+  kind: ClusterRole
+  name: nfd-manager-role
 subjects:
 - kind: ServiceAccount
   name: default
   namespace: node-feature-discovery-operator
-

--- a/config/rbac/gc/clusterrole.yaml
+++ b/config/rbac/gc/clusterrole.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-gc
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - delete
+  - list
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - delete
+  - list

--- a/config/rbac/gc/clusterrole_binding.yaml
+++ b/config/rbac/gc/clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-gc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-gc
+subjects:
+- kind: ServiceAccount
+  name: nfd-gc
+  namespace: default

--- a/config/rbac/gc/kustomization.yaml
+++ b/config/rbac/gc/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- sa.yaml
+- clusterrole.yaml
+- clusterrole_binding.yaml

--- a/config/rbac/gc/sa.yaml
+++ b/config/rbac/gc/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-gc

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -2,14 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- role.yaml
-- role_binding.yaml
-- leader_election_role.yaml
-- leader_election_role_binding.yaml
-# Comment the following 4 lines if you want to disable
+- core/
+
+- gc/
+- master/
+- prune/
+- topologyupdater/
+- worker/
+# Comment the following line if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+- auth_proxy/

--- a/config/rbac/master/clusterrole.yaml
+++ b/config/rbac/master/clusterrole.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-master
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+  - list
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturerules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - "nfd-master.nfd.kubernetes.io"
+  verbs:
+  - get
+  - update

--- a/config/rbac/master/clusterrole_binding.yaml
+++ b/config/rbac/master/clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-master
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-master
+subjects:
+- kind: ServiceAccount
+  name: nfd-master
+  namespace: node-feature-discovery-operator

--- a/config/rbac/master/kustomization.yaml
+++ b/config/rbac/master/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- sa.yaml
+- clusterrole.yaml
+- clusterrole_binding.yaml

--- a/config/rbac/master/sa.yaml
+++ b/config/rbac/master/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-master

--- a/config/rbac/nodefeaturediscovery_viewer_role.yaml
+++ b/config/rbac/nodefeaturediscovery_viewer_role.yaml
@@ -18,4 +18,3 @@ rules:
   - nodefeaturediscoveries/status
   verbs:
   - get
-

--- a/config/rbac/prune/clusterrole.yaml
+++ b/config/rbac/prune/clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-prune
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+  - update
+  - list

--- a/config/rbac/prune/clusterrole_binding.yaml
+++ b/config/rbac/prune/clusterrole_binding.yaml
@@ -1,13 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: proxy-rolebinding
+  name: nfd-prune
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: proxy-role
+  name: nfd-prune
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: nfd-prune
   namespace: node-feature-discovery-operator
-

--- a/config/rbac/prune/kustomization.yaml
+++ b/config/rbac/prune/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- sa.yaml
+- clusterrole.yaml
+- clusterrole_binding.yaml

--- a/config/rbac/prune/sa.yaml
+++ b/config/rbac/prune/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-prune

--- a/config/rbac/topologyupdater/clusterrole.yaml
+++ b/config/rbac/topologyupdater/clusterrole.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfd-topology-updater
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - update

--- a/config/rbac/topologyupdater/clusterrole_binding.yaml
+++ b/config/rbac/topologyupdater/clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-topology-updater
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfd-topology-updater
+subjects:
+- kind: ServiceAccount
+  name: nfd-topology-updater
+  namespace: node-feature-discovery

--- a/config/rbac/topologyupdater/kustomization.yaml
+++ b/config/rbac/topologyupdater/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- sa.yaml
+- clusterrole.yaml
+- clusterrole_binding.yaml

--- a/config/rbac/topologyupdater/sa.yaml
+++ b/config/rbac/topologyupdater/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-topology-updater

--- a/config/rbac/worker/kustomization.yaml
+++ b/config/rbac/worker/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- sa.yaml
+- role.yaml
+- role_binding.yaml

--- a/config/rbac/worker/role.yaml
+++ b/config/rbac/worker/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nfd-worker
+rules:
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - get
+  - create
+  - update

--- a/config/rbac/worker/role_binding.yaml
+++ b/config/rbac/worker/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nfd-worker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nfd-worker
+subjects:
+- kind: ServiceAccount
+  name: nfd-worker
+  namespace: node-feature-discovery-operator

--- a/config/rbac/worker/sa.yaml
+++ b/config/rbac/worker/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfd-worker


### PR DESCRIPTION
This will set up the various service accounts, roles and rolebindings needed by the new (refactored) controller.  These will all be applied at install (`make deploy`) time.
For clarity the current  manager setup (`config/rbac/role.yaml` and `role_binding.yaml`) are renamed, and each account is broken into its own set of files.

If applied before the new controller is made live the old controller will overwrite any changes here at reconcile time and continue to work (or at least will continue to be as broken as it is now...) so this PR can be applied safely without the refactor being completed.