### PR TITLE
Fixing prune job implementation

### DIFF
--- a/internal/controllers/nodefeaturediscovery_reconciler.go
+++ b/internal/controllers/nodefeaturediscovery_reconciler.go
@@ -330,23 +330,17 @@ func (nfdh *nodeFeatureDiscoveryHelper) handlePrune(ctx context.Context, nfdInst
 		return false, fmt.Errorf("failed to get nfd-prune job: %w", err)
 	}
 
-	deleteJob := false
 	var returnErr error
 	done := false
 	if pruneJob.Status.Succeeded > 0 {
-		deleteJob = true
 		done = true
 	}
 	if pruneJob.Status.Failed > 0 {
-		deleteJob = true
 		returnErr = fmt.Errorf("prune job's pod has failed")
 	}
-	if deleteJob {
-		err = nfdh.jobAPI.DeleteJob(ctx, pruneJob)
-		if err != nil {
-			return false, fmt.Errorf("failed to delete nfd-prune job: %w", err)
-		}
-	}
+
+	// no need to explicitly delete Prune job,
+	// it will be deleted by K8S scheduler once NFD CR is deleted from etcd
 	return done, returnErr
 }
 

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -37,7 +37,6 @@ import (
 type JobAPI interface {
 	GetJob(ctx context.Context, namespace, name string) (*batchv1.Job, error)
 	CreatePruneJob(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery) error
-	DeleteJob(ctx context.Context, j *batchv1.Job) error
 }
 
 type job struct {
@@ -104,14 +103,6 @@ func (j *job) CreatePruneJob(ctx context.Context, nfdInstance *nfdv1.NodeFeature
 	}
 
 	return j.client.Create(ctx, &pruneJob)
-}
-
-func (j *job) DeleteJob(ctx context.Context, job *batchv1.Job) error {
-	err := j.client.Delete(ctx, job)
-	if err != nil && client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("failed to delete job %s/%s: %w", job.Namespace, job.Name, err)
-	}
-	return nil
 }
 
 func getPodsTolerations() []corev1.Toleration {

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -25,9 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	nfdv1 "sigs.k8s.io/node-feature-discovery-operator/api/v1"
 	"sigs.k8s.io/node-feature-discovery-operator/internal/client"
@@ -105,44 +103,5 @@ var _ = Describe("CreatePruneJob", func() {
 
 		err = jobAPI.CreatePruneJob(ctx, &nfdCR)
 		Expect(err).To(BeNil())
-	})
-})
-
-var _ = Describe("DeleteJob", func() {
-	var (
-		ctrl   *gomock.Controller
-		clnt   *client.MockClient
-		jobAPI JobAPI
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		jobAPI = NewJobAPI(clnt, scheme)
-	})
-
-	ctx := context.Background()
-
-	deleteJob := batchv1.Job{}
-
-	It("successfull deletion", func() {
-		clnt.EXPECT().Delete(ctx, &deleteJob).Return(nil)
-
-		err := jobAPI.DeleteJob(ctx, &deleteJob)
-		Expect(err).To(BeNil())
-	})
-
-	It("job does not exist, function should return no error", func() {
-		clnt.EXPECT().Delete(ctx, &deleteJob).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever"))
-
-		err := jobAPI.DeleteJob(ctx, &deleteJob)
-		Expect(err).To(BeNil())
-	})
-
-	It("delete fails, function should return error", func() {
-		clnt.EXPECT().Delete(ctx, &deleteJob).Return(fmt.Errorf("some error"))
-
-		err := jobAPI.DeleteJob(ctx, &deleteJob)
-		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/job/mock_job.go
+++ b/internal/job/mock_job.go
@@ -54,20 +54,6 @@ func (mr *MockJobAPIMockRecorder) CreatePruneJob(ctx, nfdInstance any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePruneJob", reflect.TypeOf((*MockJobAPI)(nil).CreatePruneJob), ctx, nfdInstance)
 }
 
-// DeleteJob mocks base method.
-func (m *MockJobAPI) DeleteJob(ctx context.Context, j *v1.Job) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteJob", ctx, j)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteJob indicates an expected call of DeleteJob.
-func (mr *MockJobAPIMockRecorder) DeleteJob(ctx, j any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockJobAPI)(nil).DeleteJob), ctx, j)
-}
-
 // GetJob mocks base method.
 func (m *MockJobAPI) GetJob(ctx context.Context, namespace, name string) (*v1.Job, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
No need to explicitly delete the prune job, since it will be deleted by the K8S scheduler once the NFD CR is removed from etcd. Additionally, if the job is explicitly deleted, then the code will attempt to recreate it a second time while the NFD CR is being deleted.