### PR TITLE
Updating the operator-sdk to v1.32

### DIFF
--- a/Dockerfile.node-feature-discovery-operator-build
+++ b/Dockerfile.node-feature-discovery-operator-build
@@ -11,5 +11,9 @@ RUN go install go.uber.org/mock/mockgen@v0.3.0
 RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl
 RUN install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+RUN export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0 \
+    && curl --retry 5 -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_amd64 \
+    && chmod +x operator-sdk_linux_amd64 \
+    && install operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
 
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=nfd-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.26.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/bundle/manifests/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -1,10 +1,9 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
     api-approved.kubernetes.io: unapproved, experimental-only
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: nodefeaturediscoveries.nfd.kubernetes.io
 spec:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: nfd-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.26.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
1) updating skipper Dockerfile to include operator-sdk
2) updating bundle file with operator-sdk version