### PR TITLE
Adding Getters to the Deployment and Daemonset interfaces

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -37,6 +37,7 @@ type DaemonsetAPI interface {
 	SetTopologyDaemonsetAsDesired(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery, topologyDS *appsv1.DaemonSet) error
 	SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery, workerDS *appsv1.DaemonSet) error
 	DeleteDaemonSet(ctx context.Context, namespace, name string) error
+	GetDaemonSet(ctx context.Context, namespace, name string) (*appsv1.DaemonSet, error)
 }
 
 type daemonset struct {
@@ -99,6 +100,12 @@ func (d *daemonset) DeleteDaemonSet(ctx context.Context, namespace, name string)
 		return fmt.Errorf("failed to delete daemonset %s/%s: %w", namespace, name, err)
 	}
 	return nil
+}
+
+func (d *daemonset) GetDaemonSet(ctx context.Context, namespace, name string) (*appsv1.DaemonSet, error) {
+	ds := &appsv1.DaemonSet{}
+	err := d.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, ds)
+	return ds, err
 }
 
 func getImagePullPolicy(nfdInstance *nfdv1.NodeFeatureDiscovery) corev1.PullPolicy {

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -54,6 +54,21 @@ func (mr *MockDaemonsetAPIMockRecorder) DeleteDaemonSet(ctx, namespace, name any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDaemonSet", reflect.TypeOf((*MockDaemonsetAPI)(nil).DeleteDaemonSet), ctx, namespace, name)
 }
 
+// GetDaemonSet mocks base method.
+func (m *MockDaemonsetAPI) GetDaemonSet(ctx context.Context, namespace, name string) (*v1.DaemonSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDaemonSet", ctx, namespace, name)
+	ret0, _ := ret[0].(*v1.DaemonSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDaemonSet indicates an expected call of GetDaemonSet.
+func (mr *MockDaemonsetAPIMockRecorder) GetDaemonSet(ctx, namespace, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDaemonSet", reflect.TypeOf((*MockDaemonsetAPI)(nil).GetDaemonSet), ctx, namespace, name)
+}
+
 // SetTopologyDaemonsetAsDesired mocks base method.
 func (m *MockDaemonsetAPI) SetTopologyDaemonsetAsDesired(ctx context.Context, nfdInstance *v10.NodeFeatureDiscovery, topologyDS *v1.DaemonSet) error {
 	m.ctrl.T.Helper()

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -42,6 +42,7 @@ type DeploymentAPI interface {
 	SetMasterDeploymentAsDesired(nfdInstance *nfdv1.NodeFeatureDiscovery, masterDep *v1.Deployment) error
 	SetGCDeploymentAsDesired(nfdInstance *nfdv1.NodeFeatureDiscovery, gcDep *v1.Deployment) error
 	DeleteDeployment(ctx context.Context, namespace, name string) error
+	GetDeployment(ctx context.Context, namespace, name string) (*v1.Deployment, error)
 }
 
 type deployment struct {
@@ -142,6 +143,12 @@ func (d *deployment) DeleteDeployment(ctx context.Context, namespace, name strin
 		return fmt.Errorf("failed to delete deployment %s/%s: %w", namespace, name, err)
 	}
 	return nil
+}
+
+func (d *deployment) GetDeployment(ctx context.Context, namespace, name string) (*v1.Deployment, error) {
+	dep := &v1.Deployment{}
+	err := d.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, dep)
+	return dep, err
 }
 
 func getPodsTolerations() []corev1.Toleration {

--- a/internal/deployment/mock_deployment.go
+++ b/internal/deployment/mock_deployment.go
@@ -54,6 +54,21 @@ func (mr *MockDeploymentAPIMockRecorder) DeleteDeployment(ctx, namespace, name a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDeployment", reflect.TypeOf((*MockDeploymentAPI)(nil).DeleteDeployment), ctx, namespace, name)
 }
 
+// GetDeployment mocks base method.
+func (m *MockDeploymentAPI) GetDeployment(ctx context.Context, namespace, name string) (*v1.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeployment", ctx, namespace, name)
+	ret0, _ := ret[0].(*v1.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeployment indicates an expected call of GetDeployment.
+func (mr *MockDeploymentAPIMockRecorder) GetDeployment(ctx, namespace, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployment", reflect.TypeOf((*MockDeploymentAPI)(nil).GetDeployment), ctx, namespace, name)
+}
+
 // SetGCDeploymentAsDesired mocks base method.
 func (m *MockDeploymentAPI) SetGCDeploymentAsDesired(nfdInstance *v10.NodeFeatureDiscovery, gcDep *v1.Deployment) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Getter functions are a useful interface, and will be used in the status implementation