### PR TITLE
sync nodefeaturerules crd config with helm

### DIFF
--- a/config/crd/bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
+++ b/config/crd/bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
@@ -11,6 +11,8 @@ spec:
     kind: NodeFeatureRule
     listKind: NodeFeatureRuleList
     plural: nodefeaturerules
+    shortNames:
+    - nfr
     singular: nodefeaturerule
   scope: Namespaced
   versions:
@@ -186,6 +188,35 @@ spec:
                     name:
                       description: Name of the rule.
                       type: string
+                    taints:
+                      description: Taints to create if the rule matches.
+                      items:
+                        description: The node this Taint is attached to has the "effect"
+                          on any pod that does not tolerate the Taint.
+                        properties:
+                          effect:
+                            description: Required. The effect of the taint on pods
+                              that do not tolerate the taint. Valid effects are NoSchedule,
+                              PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Required. The taint key to be applied to
+                              a node.
+                            type: string
+                          timeAdded:
+                            description: TimeAdded represents the time at which the
+                              taint was added. It is only written for NoExecute taints.
+                            format: date-time
+                            type: string
+                          value:
+                            description: The taint value corresponding to the taint
+                              key.
+                            type: string
+                        required:
+                        - effect
+                        - key
+                        type: object
+                      type: array
                     vars:
                       additionalProperties:
                         type: string


### PR DESCRIPTION
The nodefeaturerules crd differs between _config/_ and the _deploy/helm/_  directorys, with the taints structure being missing. This PR brings the _config/_ version into sync with the _helm/_ version by adding the missing fields.

(I have checked the other CRDs and they seem to be ok, its just rules that is out of sync)