### PR TITLE
add enableTaints option to enable taint support in the crd

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -70,6 +70,12 @@ type NodeFeatureDiscoverySpec struct {
 	// as annotations, extended resources and taints) from the cluster nodes.
 	// +optional
 	PruneOnDelete bool `json:"prunerOnDelete"`
+
+	// EnableTaints enables the enable the experimental tainting feature
+	// This allows keeping nodes with specialized hardware away from running general workload i
+	// and instead leave them for workloads that need the specialized hardware.
+	// +optional
+	EnableTaints bool `json:"enableTaints"`
 }
 
 // OperandSpec describes configuration options for the operand

--- a/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -36,6 +36,12 @@ spec:
           spec:
             description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
+              enableTaints:
+                description: EnableTaints enables the enable the experimental tainting
+                  feature This allows keeping nodes with specialized hardware away
+                  from running general workload i and instead leave them for workloads
+                  that need the specialized hardware.
+                type: boolean
               extraLabelNs:
                 description: ExtraLabelNs defines the list of of allowed extra label
                   namespaces By default, only allow labels in the default `feature.node.kubernetes.io`

--- a/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: node-feature-discovery-operator
 spec:
   instance: "" # instance is empty by default
+  ## NOTE: Taints support is experimental.
+  #enableTaints: true
   #labelWhiteList: ""
   #extraLabelNs:
   #  - "example.com"

--- a/deploy/helm/nfd-operator/crds/nfd-api-crds.yaml
+++ b/deploy/helm/nfd-operator/crds/nfd-api-crds.yaml
@@ -37,6 +37,12 @@ spec:
           spec:
             description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
+              enableTaints:
+                description: EnableTaints enables the enable the experimental tainting
+                  feature This allows keeping nodes with specialized hardware away
+                  from running general workload i and instead leave them for workloads
+                  that need the specialized hardware.
+                type: boolean
               extraLabelNs:
                 description: ExtraLabelNs defines the list of of allowed extra label
                   namespaces By default, only allow labels in the default `feature.node.kubernetes.io`

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -224,6 +224,10 @@ func getArgs(nfdInstance *nfdv1.NodeFeatureDiscovery) []string {
 		args = append(args, fmt.Sprintf("--label-whitelist=%s", nfdInstance.Spec.LabelWhiteList))
 	}
 
+	if nfdInstance.Spec.EnableTaints {
+		args = append(args, "--enable-taints")
+	}
+
 	return args
 }
 


### PR DESCRIPTION
It is currently not possible to enable taints support from the operator, this PR adds that behaviour by adding an `spec.enableTaints:` boolean option to the nodefeaturediscoveries crd. This option is false by default, but when set to true adds the `--enable-taints` switch to the master args.

This is false by default, and commented out in the sample config because it is still rated as "experimental" but this allows brave users to test it.