### PR TITLE
Getting rid of pkg/version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ GOOS=linux
 PACKAGE=sigs.k8s.io/node-feature-discovery-operator
 MAIN_PACKAGE=main.go
 BIN=node-feature-discovery-operator
-LDFLAGS = -ldflags "-s -w -X sigs.k8s.io/node-feature-discovery-operator/pkg/version.version=$(VERSION)"
+LDFLAGS = -ldflags "-s -w -X main.version=$(VERSION)"
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/main.go
+++ b/main.go
@@ -40,13 +40,13 @@ import (
 	"sigs.k8s.io/node-feature-discovery-operator/internal/deployment"
 	"sigs.k8s.io/node-feature-discovery-operator/internal/job"
 	"sigs.k8s.io/node-feature-discovery-operator/internal/status"
-	"sigs.k8s.io/node-feature-discovery-operator/pkg/version"
 	// +kubebuilder:scaffold:imports
 )
 
 var (
 	// scheme holds a new scheme for the operator
-	scheme = runtime.NewScheme()
+	scheme  = runtime.NewScheme()
+	version = "undefined"
 )
 
 const (
@@ -92,7 +92,7 @@ func main() {
 	}
 
 	if *printVersion {
-		fmt.Println(ProgramName, version.Get())
+		fmt.Println(ProgramName, version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
package version is used solely to provide the code version of the operator code when executed with version argument. No need to have a public package just for that code, implementation is moved into the main package