### PR TITLE
fix: container has runAsNonRoot and image will run as root

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,8 +26,8 @@ spec:
       containers:
         - name: manager
           securityContext:
+            runAsUser: 65534
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
             allowPrivilegeEscalation: false

--- a/deploy/helm/nfd-operator/templates/deployment.yaml
+++ b/deploy/helm/nfd-operator/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
install problem: 

```
root@VM-0-10-ubuntu:/home/ubuntu/node-feature-discovery-operator# make deploy
make: go: Permission denied
go: downloading sigs.k8s.io/kustomize/kustomize/v4 v4.5.2
go: downloading github.com/spf13/cobra v1.2.1
go: downloading sigs.k8s.io/kustomize/api v0.11.2
go: downloading sigs.k8s.io/kustomize/cmd/config v0.10.4
go: downloading sigs.k8s.io/kustomize/kyaml v0.13.3
go: downloading github.com/spf13/pflag v1.0.5
go: downloading sigs.k8s.io/yaml v1.2.0
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/olekukonko/tablewriter v0.0.4
go: downloading k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
go: downloading github.com/go-errors/errors v1.0.1
go: downloading github.com/evanphx/json-patch v4.11.0+incompatible
go: downloading github.com/imdario/mergo v0.3.5
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
go: downloading github.com/stretchr/testify v1.7.0
go: downloading github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: downloading github.com/mattn/go-runewidth v0.0.7
go: downloading go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
go: downloading github.com/go-openapi/jsonreference v0.19.3
go: downloading github.com/go-openapi/swag v0.19.5
go: downloading github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
go: downloading github.com/mitchellh/mapstructure v1.4.1
go: downloading github.com/PuerkitoBio/purell v1.1.1
go: downloading github.com/go-openapi/jsonpointer v0.19.3
go: downloading github.com/mailru/easyjson v0.7.0
go: downloading golang.org/x/text v0.3.5
go: downloading golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
go: downloading github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
cd /home/ubuntu/node-feature-discovery-operator/config/manager && \
	/home/ubuntu/node-feature-discovery-operator/bin/kustomize edit set image controller=registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal
cd /home/ubuntu/node-feature-discovery-operator/config/default && \
	/home/ubuntu/node-feature-discovery-operator/bin/kustomize edit set image kube-rbac-proxy=gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
/home/ubuntu/node-feature-discovery-operator/bin/kustomize build config/default | kubectl apply -f -
namespace/node-feature-discovery-operator created
customresourcedefinition.apiextensions.k8s.io/nodefeaturediscoveries.nfd.kubernetes.io created
customresourcedefinition.apiextensions.k8s.io/nodefeaturerules.nfd.kubernetes.io created
customresourcedefinition.apiextensions.k8s.io/noderesourcetopologies.topology.node.k8s.io created
role.rbac.authorization.k8s.io/nfd-leader-election-role created
clusterrole.rbac.authorization.k8s.io/nfd-manager-role created
clusterrole.rbac.authorization.k8s.io/nfd-metrics-reader created
clusterrole.rbac.authorization.k8s.io/nfd-proxy-role created
rolebinding.rbac.authorization.k8s.io/nfd-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/nfd-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/nfd-proxy-rolebinding created
configmap/nfd-manager-config created
service/nfd-controller-manager-metrics-service created
deployment.apps/nfd-controller-manager created
root@VM-0-10-ubuntu:/home/ubuntu/node-feature-discovery-operator# kubectl get pods -A
NAMESPACE                         NAME                                             READY   STATUS                       RESTARTS   AGE
kube-system                       coredns-6f6b679f8f-56f4k                         1/1     Running                      0          2m7s
kube-system                       coredns-6f6b679f8f-t5zk4                         1/1     Running                      0          2m7s
kube-system                       etcd-cluster1-control-plane                      1/1     Running                      0          2m15s
kube-system                       kindnet-597d2                                    1/1     Running                      0          2m5s
kube-system                       kindnet-dl48m                                    1/1     Running                      0          2m6s
kube-system                       kindnet-hdq2w                                    1/1     Running                      0          2m7s
kube-system                       kube-apiserver-cluster1-control-plane            1/1     Running                      0          2m14s
kube-system                       kube-controller-manager-cluster1-control-plane   1/1     Running                      0          2m14s
kube-system                       kube-proxy-f9gr8                                 1/1     Running                      0          2m6s
kube-system                       kube-proxy-l2glv                                 1/1     Running                      0          2m7s
kube-system                       kube-proxy-mbc62                                 1/1     Running                      0          2m5s
kube-system                       kube-scheduler-cluster1-control-plane            1/1     Running                      0          2m14s
local-path-storage                local-path-provisioner-ccc7bf7fc-bg52g           1/1     Running                      0          2m7s
node-feature-discovery-operator   nfd-controller-manager-6658568db5-2fdrm          1/2     CreateContainerConfigError   0          12s

...
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  2m35s                default-scheduler  Successfully assigned node-feature-discovery-operator/nfd-controller-manager-6658568db5-2fdrm to cluster1-worker2
  Normal   Pulling    2m35s                kubelet            Pulling image "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
  Normal   Pulled     2m32s                kubelet            Successfully pulled image "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0" in 3.082s (3.082s including waiting). Image size: 19991088 bytes.
  Normal   Created    2m32s                kubelet            Created container kube-rbac-proxy
  Normal   Started    2m32s                kubelet            Started container kube-rbac-proxy
  Normal   Pulled     2m25s                kubelet            Successfully pulled image "registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal" in 6.614s (6.614s including waiting). Image size: 20938459 bytes.
  Normal   Pulled     2m24s                kubelet            Successfully pulled image "registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal" in 269ms (269ms including waiting). Image size: 20938459 bytes.
  Normal   Pulled     2m12s                kubelet            Successfully pulled image "registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal" in 138ms (138ms including waiting). Image size: 20938459 bytes.
  Normal   Pulled     106s                 kubelet            Successfully pulled image "registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal" in 130ms (130ms including waiting). Image size: 20938459 bytes.
  Normal   Pulled     91s                  kubelet            Successfully pulled image "registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal" in 133ms (133ms including waiting). Image size: 20938459 bytes.
  Normal   Pulling    77s (x7 over 2m32s)  kubelet            Pulling image "registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal"
  Warning  Failed     76s (x7 over 2m25s)  kubelet            Error: container has runAsNonRoot and image will run as root (pod: "nfd-controller-manager-6658568db5-2fdrm_node-feature-discovery-operator(869ad52b-d4ae-4314-a69b-4d7faa8148da)", container: manager)
  Normal   Pulled     76s (x2 over 119s)   kubelet            Successfully pulled image "registry.k8s.io/nfd/node-feature-discovery-operator:v0.6.0-minimal" in 135ms (135ms including waiting). Image size: 20938459 bytes.

```