### PR TITLE
Adding tolerations implementation to master and worker pod

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -239,13 +239,8 @@ func (d *daemonset) SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance
 				Labels: getWorkerLabelsAForApp("nfd-worker"),
 			},
 			Spec: corev1.PodSpec{
-				Tolerations: []corev1.Toleration{
-					{
-						Operator: "Exists",
-						Effect:   "NoSchedule",
-					},
-				},
-				Affinity: getWorkerAffinity(),
+				Tolerations: getWorkerTolerations(nfdInstance),
+				Affinity:    getWorkerAffinity(),
 
 				ServiceAccountName: "nfd-worker",
 				DNSPolicy:          corev1.DNSClusterFirstWithHostNet,

--- a/internal/daemonset/worker.go
+++ b/internal/daemonset/worker.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/utils/ptr"
+	nfdv1 "sigs.k8s.io/node-feature-discovery-operator/api/v1"
 )
 
 func getWorkerAffinity() *corev1.Affinity {
@@ -211,4 +212,15 @@ func getWorkerVolumes() []corev1.Volume {
 
 func getWorkerLabelsAForApp(name string) map[string]string {
 	return map[string]string{"app": name}
+}
+
+func getWorkerTolerations(nfdInstance *nfdv1.NodeFeatureDiscovery) []corev1.Toleration {
+	basicTolerations := []corev1.Toleration{
+		{
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+	}
+
+	return append(basicTolerations, nfdInstance.Spec.Operand.WorkerTolerations...)
 }

--- a/internal/daemonset/worker_test.go
+++ b/internal/daemonset/worker_test.go
@@ -1,0 +1,71 @@
+package daemonset
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	nfdv1 "sigs.k8s.io/node-feature-discovery-operator/api/v1"
+)
+
+var _ = Describe("getWorkerToleration", func() {
+
+	It("worker tolerations are not defined in NFD CR", func() {
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{},
+			},
+		}
+		expectedTolerations := []corev1.Toleration{
+			{
+				Operator: "Exists",
+				Effect:   "NoSchedule",
+			},
+		}
+
+		res := getWorkerTolerations(&nfdCR)
+		Expect(res).To(Equal(expectedTolerations))
+	})
+
+	It("worker tolerations are defined in NFD CR", func() {
+		workerTolerations := []corev1.Toleration{
+			{
+				Key:      "key1",
+				Value:    "value1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "key1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{
+					WorkerTolerations: workerTolerations,
+				},
+			},
+		}
+		expectedTolerations := []corev1.Toleration{
+			{
+				Operator: "Exists",
+				Effect:   "NoSchedule",
+			},
+			{
+				Key:      "key1",
+				Value:    "value1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "key1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+
+		res := getWorkerTolerations(&nfdCR)
+		Expect(res).To(Equal(expectedTolerations))
+	})
+})

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -74,7 +74,7 @@ func (d *deployment) SetMasterDeploymentAsDesired(nfdInstance *nfdv1.NodeFeature
 				ServiceAccountName: "nfd-master",
 				DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 				RestartPolicy:      corev1.RestartPolicyAlways,
-				Tolerations:        getPodsTolerations(),
+				Tolerations:        getPodsTolerations(nfdInstance),
 				Affinity:           getPodsAffinity(),
 				Containers: []corev1.Container{
 					{
@@ -151,8 +151,8 @@ func (d *deployment) GetDeployment(ctx context.Context, namespace, name string) 
 	return dep, err
 }
 
-func getPodsTolerations() []corev1.Toleration {
-	return []corev1.Toleration{
+func getPodsTolerations(nfdInstance *nfdv1.NodeFeatureDiscovery) []corev1.Toleration {
+	basicTolerations := []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: corev1.TolerationOpEqual,
@@ -164,6 +164,8 @@ func getPodsTolerations() []corev1.Toleration {
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	}
+
+	return append(basicTolerations, nfdInstance.Spec.Operand.MasterTolerations...)
 }
 
 func getPodsAffinity() *corev1.Affinity {


### PR DESCRIPTION
This commit add tolerations defined in the WorkerTolerations field of the NFD CR to the worker daemonset tolerations definition.It also does the same for master deployment based on the MasterTolerations field of the NFD CR