### PR TITLE
Allowing to configure priority class for the worker pods

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -107,6 +107,9 @@ type OperandSpec struct {
 
 	// MasterEnv defines environment variables to be added to the master deployment
 	MasterEnvs []corev1.EnvVar `json:"masterEnvs,omitempty"`
+
+	// WorkerPriorityClassName allows setting a specific priority class for the worker pods
+	WorkerPriorityClassName string `json:"workerPriorityClassName,omitempty"`
 }
 
 // ConfigMap describes configuration options for the NFD worker

--- a/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
@@ -340,6 +340,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  workerPriorityClassName:
+                    description: WorkerPriorityClassName allows setting a specific
+                      priority class for the worker pods
+                    type: string
                   workerTolerations:
                     description: WorkerTolerations defines tolerations to be applied
                       to the worker Daemonset

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -262,7 +262,8 @@ func (d *daemonset) SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance
 						SecurityContext: getWorkerSecurityContext(),
 					},
 				},
-				Volumes: getWorkerVolumes(),
+				Volumes:           getWorkerVolumes(),
+				PriorityClassName: nfdInstance.Spec.Operand.WorkerPriorityClassName,
 			},
 		},
 	}

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -94,7 +94,8 @@ var _ = Describe("SetWorkerDaemonsetAsDesired", func() {
 		nfdCR := nfdv1.NodeFeatureDiscovery{
 			Spec: nfdv1.NodeFeatureDiscoverySpec{
 				Operand: nfdv1.OperandSpec{
-					Image: "test-image",
+					Image:                   "test-image",
+					WorkerPriorityClassName: "check-priority-class",
 				},
 			},
 		}

--- a/internal/daemonset/testdata/test_worker_daemonset.yaml
+++ b/internal/daemonset/testdata/test_worker_daemonset.yaml
@@ -99,6 +99,7 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
+      priorityClassName: check-priority-class
       volumes:
       - hostPath:
           path: /boot


### PR DESCRIPTION
This PR adds a WorkerPriorityClassName field to the operand configuration in NFD, to allow user to configure priority class name for the worker pods